### PR TITLE
fix: skip husky in Docker/CI and gate Vercel deploy on CI success

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,3 +180,22 @@ jobs:
         run: |
           echo "## Docker Image" >> $GITHUB_STEP_SUMMARY
           echo "Tags: ${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
+
+  # ─── Vercel 生产部署（仅 main 分支，CI 全部通过后触发）────────────────────────
+  deploy:
+    name: Deploy to Vercel
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    steps:
+      - name: Trigger Vercel production deployment
+        run: |
+          curl -s -X POST "${{ secrets.VERCEL_DEPLOY_HOOK_URL }}" \
+            -o /tmp/deploy_response.json
+          cat /tmp/deploy_response.json
+
+      - name: Deployment summary
+        run: |
+          echo "## Vercel Deployment" >> $GITHUB_STEP_SUMMARY
+          echo "Production deployment triggered after all CI checks passed." >> $GITHUB_STEP_SUMMARY
+          echo "URL: https://arch-mind.vercel.app" >> $GITHUB_STEP_SUMMARY

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,16 @@ release/*     ← 发布分支，从 develop 切出，测试通过后合并到 m
 
 **禁止**直接向 `main` 分支提交代码（GitHub Branch Protection 已强制执行）。
 
+#### 0.2.1 Claude Code 默认行为规则
+
+**除非用户明确说"直接提交到 main"或"直接 push 到 main"，否则 Claude Code 必须：**
+
+1. 在功能分支（`feature/*` 或 `fix/*`）上进行所有代码修改
+2. 完成后 push 功能分支到远程
+3. 创建 PR（提供 PR 描述供用户在 GitHub 上合并）
+
+**禁止**在未获得用户明确授权的情况下直接操作 `main` 分支。
+
 #### 0.3 标准开发流程
 
 ```bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ COPY package.json pnpm-lock.yaml ./
 
 # 安装全部依赖（包含 dev，以便原生模块能正确编译）
 # 之后用 --prod 过滤只保留生产依赖
+# DOCKER_BUILD=1 用于跳过 husky prepare 脚本
+ENV DOCKER_BUILD=1
 RUN pnpm install --frozen-lockfile
 RUN pnpm prune --prod
 
@@ -32,6 +34,7 @@ WORKDIR /app
 
 # 复制依赖文件并安装全部依赖
 COPY package.json pnpm-lock.yaml ./
+ENV DOCKER_BUILD=1
 RUN pnpm install --frozen-lockfile
 
 # 复制源代码

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"generate": "nuxt generate",
 		"preview": "nuxt preview",
 		"postinstall": "nuxt prepare",
-		"prepare": "husky",
+		"prepare": "node --eval \"process.exit(process.env.CI || process.env.DOCKER_BUILD ? 0 : 1)\" || husky",
 		"lint": "eslint .",
 		"typecheck": "nuxt typecheck",
 		"format": "prettier --write \"**/*.{js,ts,vue,json,md,css}\"",


### PR DESCRIPTION
## Summary

- **Docker 构建修复**：`pnpm prune --prod` 后触发 `prepare` 脚本导致 `husky: not found` 报错，通过在 `package.json` 中判断 `CI` / `DOCKER_BUILD` 环境变量跳过 husky 解决
- **Vercel 部署顺序修复**：禁用 Vercel Git 自动部署，改由 GitHub Actions `deploy` job 在 lint + test + build 全部通过后，通过 Deploy Hook 触发 Vercel 生产部署
- **CLAUDE.md**：补充 0.2.1 节，记录 Claude Code 默认在功能分支工作的规则

## Changes

| 文件 | 变更 |
|------|------|
| `package.json` | `prepare` 脚本在 `CI=true` 或 `DOCKER_BUILD=1` 时跳过 husky |
| `Dockerfile` | deps 和 builder 两个 stage 均设置 `ENV DOCKER_BUILD=1` |
| `.github/workflows/ci.yml` | 新增 `deploy` job，`needs: [build]`，仅在 main push 且 CI 全通过后调用 Vercel Deploy Hook |
| `CLAUDE.md` | 新增 0.2.1 节：Claude Code 默认分支行为规则 |

## Test plan

- [ ] PR 合并后确认 GitHub Actions CI 全部通过（lint → test → build → docker → deploy）
- [ ] 确认 Vercel 部署在 CI 通过后才触发（不再在 push 时立即开始）
- [ ] 本地 `pnpm install` 仍正常触发 husky（非 CI 环境）

🤖 Generated with [Claude Code](https://claude.com/claude-code)