### PR TITLE
feat: async queue processing for batch upload (fix #4)

### DIFF
--- a/server/api/documents/batch-status.post.ts
+++ b/server/api/documents/batch-status.post.ts
@@ -1,0 +1,89 @@
+/**
+ * POST /api/documents/batch-status
+ * 批量查询文档处理状态
+ *
+ * 用途: 批量上传后，前端通过此接口轮询多个文档的处理进度
+ * 请求体: { documentIds: string[] }
+ * 响应: 各文档的 processingStatus、progress、chunks/vectors 数量
+ */
+
+import { z } from 'zod'
+import { DocumentDAO } from '~/lib/db/dao/document-dao'
+
+const BodySchema = z.object({
+  documentIds: z.array(z.string().uuid()).min(1).max(100)
+})
+
+export default defineEventHandler(async (event) => {
+  const userId = requireAuth(event)
+
+  const body = await readBody(event)
+  const parsed = BodySchema.safeParse(body)
+  if (!parsed.success) {
+    throw createError({
+      statusCode: 400,
+      message: parsed.error.errors[0]?.message || 'Invalid request body'
+    })
+  }
+
+  const { documentIds } = parsed.data
+
+  // 批量查询（避免 N+1）
+  const docMap = await DocumentDAO.findByIds(documentIds)
+
+  const statuses = documentIds.map((id) => {
+    const doc = docMap.get(id)
+    if (!doc) {
+      return { documentId: id, found: false }
+    }
+
+    // 只返回属于当前用户的文档状态
+    if (doc.userId && doc.userId !== userId) {
+      return { documentId: id, found: false }
+    }
+
+    return {
+      documentId: id,
+      found: true,
+      title: doc.title,
+      status: doc.processingStatus,
+      error: doc.processingError,
+      chunksCount: doc.chunksCount,
+      vectorsCount: doc.vectorsCount,
+      startedAt: doc.processingStartedAt,
+      completedAt: doc.processingCompletedAt,
+      progress: calculateProgress(doc)
+    }
+  })
+
+  const allDone = statuses.every(
+    s => !s.found || s.status === 'completed' || s.status === 'failed'
+  )
+
+  return {
+    success: true,
+    data: {
+      statuses,
+      allCompleted: allDone,
+      summary: {
+        total: documentIds.length,
+        pending: statuses.filter(s => s.status === 'pending').length,
+        processing: statuses.filter(s => s.status === 'processing').length,
+        completed: statuses.filter(s => s.status === 'completed').length,
+        failed: statuses.filter(s => s.status === 'failed').length
+      }
+    }
+  }
+})
+
+function calculateProgress(document: any): number {
+  if (document.processingStatus === 'completed') return 100
+  if (document.processingStatus === 'failed') return 0
+  if (document.processingStatus === 'processing') {
+    if (document.chunksCount > 0 && document.vectorsCount > 0) {
+      return Math.min(90, (document.vectorsCount / document.chunksCount) * 90)
+    }
+    return 50
+  }
+  return 0
+}

--- a/server/utils/document-processing.ts
+++ b/server/utils/document-processing.ts
@@ -1,0 +1,88 @@
+/**
+ * 文档异步处理工具
+ * 供 upload.post.ts 和 batch-upload.post.ts 共用
+ */
+
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import YAML from 'js-yaml'
+import { DocumentDAO } from '~/lib/db/dao/document-dao'
+import { DocumentProcessingPipeline } from '~/lib/rag/pipeline'
+import { EmbeddingServiceFactory } from '~/lib/rag/embedding-adapter'
+import { getModelManager } from '~/lib/ai/manager'
+
+/**
+ * 异步处理文档向量化（fire-and-forget）
+ * 调用方不需要 await，失败不影响主流程
+ */
+export async function processDocumentAsync(documentId: string, content: string): Promise<void> {
+  console.log(`[AsyncQueue] Starting processing for document: ${documentId}`)
+
+  await DocumentDAO.updateProcessingStatus(documentId, 'processing', {
+    startedAt: new Date()
+  })
+
+  try {
+    const runtimeConfig = useRuntimeConfig()
+    const glmApiKey = runtimeConfig.glmApiKey as string | undefined
+    const openaiApiKey = runtimeConfig.openaiApiKey as string | undefined
+
+    const config = {
+      anthropicApiKey: runtimeConfig.anthropicApiKey,
+      openaiApiKey: runtimeConfig.openaiApiKey,
+      googleApiKey: runtimeConfig.googleApiKey,
+      glmApiKey: runtimeConfig.glmApiKey,
+      dashscopeApiKey: runtimeConfig.dashscopeApiKey,
+      baiduApiKey: runtimeConfig.baiduApiKey,
+      deepseekApiKey: runtimeConfig.deepseekApiKey,
+      ollamaBaseUrl: runtimeConfig.ollamaBaseUrl
+    }
+    const modelManager = getModelManager(config)
+    const defaultModelId = modelManager.getDefaultModelId()
+
+    const configPath = join(process.cwd(), 'config', 'ai-models.yaml')
+    const configContent = readFileSync(configPath, 'utf-8')
+    const parsed = YAML.load(configContent) as { ai_models: { models: Record<string, any> } }
+    const modelConfig = parsed.ai_models.models[defaultModelId]
+
+    if (!modelConfig) {
+      console.warn(`[AsyncQueue] No model config for ${defaultModelId}, skipping vectorization`)
+      await DocumentDAO.updateProcessingStatus(documentId, 'completed', {
+        completedAt: new Date()
+      })
+      return
+    }
+
+    const embeddingAdapter = await EmbeddingServiceFactory.createFromModelConfig(
+      modelConfig,
+      { glmApiKey, openaiApiKey }
+    )
+
+    if (embeddingAdapter) {
+      const modelInfo = embeddingAdapter.getModelInfo()
+      console.log(`[AsyncQueue] Using ${modelInfo.provider} embedding for document: ${documentId}`)
+
+      const pipeline = new DocumentProcessingPipeline({ embeddingAdapter })
+      const result = await pipeline.process(documentId, content)
+
+      await DocumentDAO.updateProcessingStatus(documentId, 'completed', {
+        chunksCount: result.chunksCreated,
+        vectorsCount: result.vectorsAdded,
+        completedAt: new Date()
+      })
+
+      console.log(`[AsyncQueue] Completed: ${documentId} (chunks=${result.chunksCreated}, vectors=${result.vectorsAdded})`)
+    } else {
+      console.warn(`[AsyncQueue] Model ${defaultModelId} does not support embedding, skipping vectorization`)
+      await DocumentDAO.updateProcessingStatus(documentId, 'completed', {
+        completedAt: new Date()
+      })
+    }
+  } catch (error) {
+    console.error(`[AsyncQueue] Failed for document ${documentId}:`, error)
+    await DocumentDAO.updateProcessingStatus(documentId, 'failed', {
+      error: error instanceof Error ? error.message : 'Unknown error',
+      completedAt: new Date()
+    })
+  }
+}


### PR DESCRIPTION
## Summary

- 将 `processDocumentAsync` 提取到 `server/utils/document-processing.ts` 共享工具，消除 `upload.post.ts` 和 `batch-upload.post.ts` 中的重复代码
- `batch-upload` 现在在存储上传和 DB 建档完成后立即返回 `documentIds`，不再阻塞等待向量化
- 向量化在后台 fire-and-forget 异步执行，失败会记录错误状态但不影响上传响应
- 新增 `POST /api/documents/batch-status` 端点，前端可批量轮询多个文档处理进度

## Changes

| 文件 | 变更 |
|------|------|
| `server/utils/document-processing.ts` | 新增：共享异步处理工具 |
| `server/api/documents/batch-upload.post.ts` | 修改：改为异步队列模式 |
| `server/api/documents/batch-status.post.ts` | 新增：批量状态查询端点 |
| `server/api/documents/upload.post.ts` | 修改：复用共享工具，删除重复代码 |

## Test plan

- [ ] 批量上传多个文件，确认立即返回 `{ documentIds, queuedCount }`
- [ ] 调用 `GET /api/documents/:id/status` 轮询单个文档处理状态
- [ ] 调用 `POST /api/documents/batch-status` 批量查询进度
- [ ] 确认向量化完成后状态变为 `completed`，`chunksCount`/`vectorsCount` 有值
- [ ] 上传重复文件，确认返回 `duplicate: true`，不重复向量化

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)