### PR TITLE
feat: SSE real-time progress in DocumentUpload (fix #12)

### DIFF
--- a/components/documents/DocumentUpload.vue
+++ b/components/documents/DocumentUpload.vue
@@ -15,7 +15,7 @@
         @change="handleFileSelect"
       >
 
-      <div v-if="!uploading">
+      <div v-if="!uploading && !processing">
         <CloudUpload class="w-12 h-12 mx-auto mb-4 text-muted-foreground" />
         <p class="text-foreground mb-2">
           {{ $t('documents.upload.dragDrop') }}
@@ -25,14 +25,34 @@
         </p>
       </div>
 
-      <div v-else>
+      <!-- 上传阶段 -->
+      <div v-else-if="uploading">
         <Progress :model-value="uploadProgress" class="mb-2" />
         <p class="text-muted-foreground">
           {{ $t('documents.upload.uploading', { progress: uploadProgress }) }}
         </p>
       </div>
+
+      <!-- 向量化处理阶段 -->
+      <div v-else-if="processing">
+        <div class="flex items-center justify-center mb-3">
+          <Loader2 class="w-8 h-8 animate-spin text-primary" />
+        </div>
+        <Progress :model-value="sseProgress" class="mb-2" />
+        <p class="text-sm text-muted-foreground">
+          <template v-if="sseStatus === 'pending'">{{ $t('documents.upload.queued') }}</template>
+          <template v-else-if="sseStatus === 'processing'">
+            {{ $t('documents.upload.vectorizing') }}
+            <span v-if="sseChunksCount && sseVectorsCount">
+              ({{ sseVectorsCount }}/{{ sseChunksCount }} chunks)
+            </span>
+          </template>
+          <template v-else>{{ $t('documents.upload.processing') }}</template>
+        </p>
+      </div>
     </div>
 
+    <!-- 错误提示 -->
     <Alert v-if="error" variant="destructive">
       <AlertCircle class="h-4 w-4" />
       <AlertTitle>{{ $t('common.error') }}</AlertTitle>
@@ -42,7 +62,8 @@
 </template>
 
 <script setup lang="ts">
-import { CloudUpload, AlertCircle } from 'lucide-vue-next'
+import { CloudUpload, AlertCircle, Loader2 } from 'lucide-vue-next'
+import { useDocumentSSE } from '~/composables/useDocumentSSE'
 
 const { t } = useI18n()
 
@@ -54,23 +75,35 @@ const fileInput = ref<HTMLInputElement>()
 const uploading = ref(false)
 const uploadProgress = ref(0)
 const error = ref('')
+const processing = ref(false)
+
+const {
+  status: sseStatus,
+  progress: sseProgress,
+  chunksCount: sseChunksCount,
+  vectorsCount: sseVectorsCount,
+  isCompleted: sseCompleted,
+  isFailed: sseFailed,
+  subscribe: sseSubscribe,
+  reset: sseReset
+} = useDocumentSSE()
 
 const emit = defineEmits<{
   uploaded: [documentId: string];
 }>()
 
-async function handleFileSelect (event: Event) {
+function handleFileSelect (event: Event) {
   const target = event.target as HTMLInputElement
   const file = target.files?.[0]
   if (file) {
-    await uploadFile(file)
+    uploadFile(file)
   }
 }
 
-async function handleDrop (event: DragEvent) {
+function handleDrop (event: DragEvent) {
   const file = event.dataTransfer?.files[0]
   if (file) {
-    await uploadFile(file)
+    uploadFile(file)
   }
 }
 
@@ -78,6 +111,8 @@ async function uploadFile (file: File) {
   error.value = ''
   uploading.value = true
   uploadProgress.value = 0
+  processing.value = false
+  sseReset()
 
   try {
     const formData = new FormData()
@@ -92,14 +127,30 @@ async function uploadFile (file: File) {
     })
 
     uploadProgress.value = 100
-    emit('uploaded', response.data.id)
+    uploading.value = false
+
+    // 上传成功后订阅 SSE，展示向量化进度
+    const documentId = response.data.id
+    processing.value = true
+
+    sseSubscribe(documentId, (statusEvent) => {
+      if (statusEvent.status === 'completed' || statusEvent.status === 'failed') {
+        processing.value = false
+        emit('uploaded', documentId)
+      }
+    })
   } catch (err: any) {
     error.value = err.message || t('documents.upload.uploadFailed')
+    uploading.value = false
   } finally {
-    setTimeout(() => {
-      uploading.value = false
-      uploadProgress.value = 0
-    }, 500)
+    uploadProgress.value = 0
   }
 }
+
+// 监听 SSE 完成/失败（作为 sseSubscribe 回调的补充）
+watch([sseCompleted, sseFailed], ([completed, failed]) => {
+  if ((completed || failed) && processing.value) {
+    processing.value = false
+  }
+})
 </script>

--- a/lang/en.json
+++ b/lang/en.json
@@ -383,7 +383,10 @@
       "dragDrop": "Drag and drop files here or click to select files",
       "supportedFormats": "Supports PDF, DOCX, Markdown formats, maximum 10MB",
       "uploading": "Uploading... {progress}%",
-      "uploadFailed": "Upload failed"
+      "uploadFailed": "Upload failed",
+      "queued": "Queued, waiting for vectorization...",
+      "vectorizing": "Vectorizing...",
+      "processing": "Processing document..."
     },
     "details": {
       "title": "Document Details",

--- a/lang/zh-CN.json
+++ b/lang/zh-CN.json
@@ -383,7 +383,10 @@
       "dragDrop": "拖拽文件到此处或点击选择文件",
       "supportedFormats": "支持 PDF, DOCX, Markdown 格式,最大 10MB",
       "uploading": "上传中... {progress}%",
-      "uploadFailed": "上传失败"
+      "uploadFailed": "上传失败",
+      "queued": "已加入队列，等待向量化处理...",
+      "vectorizing": "向量化处理中...",
+      "processing": "文档处理中..."
     },
     "details": {
       "title": "文档详情",


### PR DESCRIPTION
## Summary

- `DocumentUpload` 上传完成后自动订阅 `GET /api/documents/:id/events` SSE 端点
- 在向量化阶段展示实时进度条 + spinner，状态文案随 `pending`/`processing` 变化
- 有 chunk 数据时显示 `(N/M chunks)` 精细进度
- SSE 连接在 `completed`/`failed` 时自动关闭，`uploaded` 事件在处理完成后才 emit
- 补充 i18n 文案：`queued`、`vectorizing`、`processing`（中英文）

## Changes

| 文件 | 变更 |
|------|------|
| `components/documents/DocumentUpload.vue` | 接入 `useDocumentSSE`，新增向量化进度 UI |
| `lang/zh-CN.json` | 新增 3 个文案 key |
| `lang/en.json` | 新增 3 个文案 key |

## Test plan

- [ ] 上传文档后，上传进度消失，出现 spinner + 进度条
- [ ] 状态文案从「已加入队列」→「向量化处理中 (N/M chunks)」变化
- [ ] 向量化完成后 dialog 自动关闭，文档列表刷新
- [ ] 向量化失败时 dialog 关闭，可在文档列表看到失败状态

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)