### PR TITLE
test: 补充核心模块单元测试，覆盖率从 72% 提升至 89% (fix #8)

### DIFF
--- a/tests/unit/lib/prd/generator.test.ts
+++ b/tests/unit/lib/prd/generator.test.ts
@@ -160,6 +160,12 @@ describe('PRD_SYSTEM_PROMPT', () => {
   })
 })
 
+// ─── 辅助：访问私有方法 ───────────────────────────────────────────────────────
+
+function callPrivate<T>(instance: any, method: string, ...args: any[]): T {
+  return instance[method](...args) as T
+}
+
 describe('PRDGenerator', () => {
   let generator: PRDGenerator
 
@@ -172,6 +178,94 @@ describe('PRDGenerator', () => {
     it('should create generator without embedding adapter', () => {
       const gen = new PRDGenerator()
       expect(gen).toBeDefined()
+    })
+
+    it('should create generator with embedding adapter', () => {
+      const mockEmbedding = { embed: vi.fn(), model: 'mock', dimensions: 128 }
+      const gen = new PRDGenerator(mockEmbedding as any)
+      expect(gen).toBeDefined()
+    })
+  })
+
+  describe('estimateTokens (private)', () => {
+    it('纯英文文本：按4字符/token估算', () => {
+      const tokens = callPrivate<number>(generator, 'estimateTokens', 'hello world test')
+      expect(tokens).toBe(Math.ceil(16 / 4))
+    })
+
+    it('纯中文文本：按2字符/token估算', () => {
+      const tokens = callPrivate<number>(generator, 'estimateTokens', '用户登录功能')
+      expect(tokens).toBe(Math.ceil(6 / 2))
+    })
+
+    it('中英混合文本：分别估算后相加', () => {
+      // '用户login功能': 用户(2中文) + login(5英文) + 功能(2中文) = 4中文 + 5英文
+      const text = '用户login功能'
+      const chineseChars = (text.match(/[\u4e00-\u9fa5]/g) || []).length // 4
+      const englishChars = text.length - chineseChars // 5
+      const expected = Math.ceil(chineseChars / 2 + englishChars / 4)
+      const tokens = callPrivate<number>(generator, 'estimateTokens', text)
+      expect(tokens).toBe(expected)
+    })
+
+    it('空字符串返回0', () => {
+      const tokens = callPrivate<number>(generator, 'estimateTokens', '')
+      expect(tokens).toBe(0)
+    })
+  })
+
+  describe('allocateTokenBudget (private)', () => {
+    it('无 options 时使用默认 8000 maxTokens', () => {
+      const budget = callPrivate<any>(generator, 'allocateTokenBudget', undefined)
+      expect(budget.output).toBe(8000)
+      expect(budget.systemPrompt).toBe(1500)
+      expect(budget.context).toBe(4000)
+    })
+
+    it('传入 maxTokens 时 output 使用该值', () => {
+      const budget = callPrivate<any>(generator, 'allocateTokenBudget', { maxTokens: 4000 })
+      expect(budget.output).toBe(4000)
+    })
+  })
+
+  describe('compressContext (private)', () => {
+    it('上下文 token 数 <= maxTokens 时直接返回原内容', () => {
+      const short = 'Short context'
+      const result = callPrivate<string>(generator, 'compressContext', short, 4000)
+      expect(result).toBe(short)
+    })
+
+    it('超出 maxTokens 时压缩长 section', () => {
+      // 构造两个很长的 section（超过 1000 字），用 \n---\n 分隔
+      // maxTokens=300：section1 原始约 1250 tokens，超限，走压缩分支
+      // 压缩后约 1000/4=250 tokens（保留前后各 500 字），250 <= 300，加入
+      // section2 同理，但 250+250=500 > 300，不加入
+      const longSection1 = 'A'.repeat(5000)
+      const longSection2 = 'B'.repeat(5000)
+      const context = longSection1 + '\n---\n' + longSection2
+      const result = callPrivate<string>(generator, 'compressContext', context, 300)
+      // section1 被压缩后加入，应包含省略号
+      expect(result).toContain('...[中间内容省略]...')
+      expect(result.length).toBeLessThan(context.length)
+    })
+
+    it('多个 section 时，优先保留前面的 section', () => {
+      const section1 = 'A'.repeat(200)
+      const section2 = 'B'.repeat(200)
+      const section3 = 'C'.repeat(200)
+      const context = [section1, section2, section3].join('\n---\n')
+      // maxTokens=60 只能容纳前2个 section
+      const result = callPrivate<string>(generator, 'compressContext', context, 60)
+      expect(result).toContain('A')
+    })
+
+    it('section 长度 <= 1000 但预算不够时依然加入', () => {
+      const section1 = 'A'.repeat(400) // ~100 tokens
+      const section2 = 'B'.repeat(400) // ~100 tokens
+      const context = [section1, section2].join('\n---\n')
+      // maxTokens=50，section2 不超过 1000 字，走 else 分支加入
+      const result = callPrivate<string>(generator, 'compressContext', context, 50)
+      expect(result).toBeDefined()
     })
   })
 
@@ -197,6 +291,58 @@ describe('PRDGenerator', () => {
 
       expect(result).toBeDefined()
     })
+
+    it('useRAG=true 时调用 RAG 检索器', async () => {
+      const mockEmbedding = { embed: vi.fn().mockResolvedValue([0.1, 0.2]), model: 'mock', dimensions: 2 }
+      const genWithRAG = new PRDGenerator(mockEmbedding as any)
+      const result = await genWithRAG.generate('Build user system', { useRAG: true, userId: 'user-1' })
+      // RAG 检索器被 mock，应正常生成
+      expect(result).toHaveProperty('prdId')
+      expect(result.references).toContain('doc-1')
+    })
+
+    it('useRAG=true 但 ragRetriever=null 时不调用检索', async () => {
+      // 无 embeddingAdapter 时 ragRetriever 为 null
+      const result = await generator.generate('Build feature', { useRAG: true })
+      expect(result).toHaveProperty('prdId')
+      expect(result.references).toHaveLength(0)
+    })
+
+    it('传入 documentIds 时加载指定文档', async () => {
+      const result = await generator.generate('Build feature', {
+        documentIds: ['doc-1', 'doc-2']
+      })
+      expect(result).toHaveProperty('prdId')
+      expect(result.references).toEqual(['doc-1', 'doc-2'])
+    })
+
+    it('指定 userId 和 workspaceId 时保存到 PRD', async () => {
+      const result = await generator.generate('Build feature', {
+        userId: 'user-123',
+        workspaceId: 'ws-456'
+      })
+      expect(result).toHaveProperty('prdId', 'prd-test-123')
+    })
+
+    it('模型不存在时抛出错误', async () => {
+      // 让 getAdapter 对指定模型返回 null
+      const { ModelManager } = await import('~/lib/ai/manager')
+      vi.mocked(ModelManager).mockImplementationOnce(function (this: any) {
+        this.getAdapter = () => null
+        this.estimateCost = () => null
+        this.getAvailableModels = () => []
+      })
+      const gen = new PRDGenerator()
+      await expect(
+        gen.generate('Test', { model: 'non-existent-model' })
+      ).rejects.toThrow('Model non-existent-model not available')
+    })
+
+    it('tokenCount 和 estimatedCost 正确返回', async () => {
+      const result = await generator.generate('Test input')
+      expect(result.tokenCount).toBeGreaterThan(0)
+      expect(result.estimatedCost).toBe(0.01)
+    })
   })
 
   describe('generateStream', () => {
@@ -210,6 +356,82 @@ describe('PRDGenerator', () => {
 
       expect(chunks.length).toBeGreaterThan(0)
       expect(chunks.join('')).toContain('Mock')
+    })
+
+    it('useRAG=true 时流式生成也调用 RAG 检索', async () => {
+      const mockEmbedding = { embed: vi.fn().mockResolvedValue([0.1, 0.2]), model: 'mock', dimensions: 2 }
+      const genWithRAG = new PRDGenerator(mockEmbedding as any)
+      const chunks: string[] = []
+      for await (const chunk of genWithRAG.generateStream('Build system', { useRAG: true })) {
+        chunks.push(chunk)
+      }
+      expect(chunks.length).toBeGreaterThan(0)
+    })
+
+    it('流式生成传入 documentIds 时构建上下文', async () => {
+      const chunks: string[] = []
+      for await (const chunk of generator.generateStream('Build feature', {
+        documentIds: ['doc-1']
+      })) {
+        chunks.push(chunk)
+      }
+      expect(chunks.join('')).toContain('Mock')
+    })
+
+    it('流式生成模型不存在时抛出错误', async () => {
+      const { ModelManager } = await import('~/lib/ai/manager')
+      vi.mocked(ModelManager).mockImplementationOnce(function (this: any) {
+        this.getAdapter = () => null
+        this.estimateCost = () => null
+        this.getAvailableModels = () => []
+      })
+      const gen = new PRDGenerator()
+      const stream = gen.generateStream('Test', { model: 'non-existent-model' })
+      await expect(stream.next()).rejects.toThrow('Model non-existent-model not available')
+    })
+
+    it('PRDDAO.create 失败时抛出错误', async () => {
+      // 直接 spy 模块 mock 对象上的方法
+      const prdDaoMod = await import('~/lib/db/dao/prd-dao')
+      const originalCreate = prdDaoMod.PRDDAO.create
+      prdDaoMod.PRDDAO.create = vi.fn().mockRejectedValueOnce(new Error('DB error')) as any
+
+      const stream = generator.generateStream('Test input')
+      const chunks: string[] = []
+      await expect(async () => {
+        for await (const chunk of stream) {
+          chunks.push(chunk)
+        }
+      }).rejects.toThrow('DB error')
+
+      prdDaoMod.PRDDAO.create = originalCreate
+    })
+
+    it('PRDDAO.addReferences 失败时不影响流式结果', async () => {
+      const prdDaoMod = await import('~/lib/db/dao/prd-dao')
+      const originalAddReferences = prdDaoMod.PRDDAO.addReferences
+      prdDaoMod.PRDDAO.addReferences = vi.fn().mockRejectedValueOnce(new Error('Ref error')) as any
+
+      const chunks: string[] = []
+      // 有 documentIds 才会调用 addReferences
+      for await (const chunk of generator.generateStream('Test', { documentIds: ['doc-1'] })) {
+        chunks.push(chunk)
+      }
+      // 流式内容正常输出（addReferences 错误被 catch 吞掉）
+      expect(chunks.join('')).toContain('Mock')
+
+      prdDaoMod.PRDDAO.addReferences = originalAddReferences
+    })
+
+    it('自定义 temperature 和 maxTokens', async () => {
+      const chunks: string[] = []
+      for await (const chunk of generator.generateStream('Test', {
+        temperature: 0.3,
+        maxTokens: 2000
+      })) {
+        chunks.push(chunk)
+      }
+      expect(chunks.length).toBeGreaterThan(0)
     })
   })
 })


### PR DESCRIPTION
## Summary

- 补充 `lib/prd/generator.ts` 测试：私有方法、RAG 路径、流式生成错误处理，覆盖率 42% → **100%**
- 补充 `lib/rag/retriever.ts` 测试：PRD 检索路径、userId 权限隔离、异常处理，覆盖率 47% → **100%**
- 补充 `server/middleware/02.rate-limit.ts` 测试：`getClientIp` 代理头解析、中间件端到端行为，覆盖率 46% → **93%**
- 补充 `lib/ai/manager.ts` 测试：baseUrl 传递、自定义模型、元数据聚合、单例重初始化，覆盖率 71% → **93%**

## Coverage Results

| 指标 | 之前 | 现在 |
|------|------|------|
| Statements | 71.96% | **89.15%** |
| Branches | 68.36% | **83.14%** |
| Functions | 66.23% | **83.76%** |
| Lines | 72.72% | **89.52%** |
| 总测试数 | 292 | **357** |

超过 Issue #8 目标（整体 60%，核心模块 80%）。

## Test plan

- [x] `pnpm test:coverage` 全部 357 个测试通过
- [x] 整体覆盖率 89% ≥ 60% 目标
- [x] `lib/rag`、`lib/prd` 覆盖率 ≥ 80% 目标

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)