### PR TITLE
fix: Vercel upload issues - missing yaml file and auto-migration

### DIFF
--- a/migrations/add-documents-processing-fields.sql
+++ b/migrations/add-documents-processing-fields.sql
@@ -1,0 +1,39 @@
+-- 扩展 documents 表，添加存储和处理状态字段
+-- Migration: add-documents-processing-fields
+-- Created at: 2026-02-25
+
+-- 添加存储相关字段
+ALTER TABLE documents
+ADD COLUMN IF NOT EXISTS storage_provider TEXT DEFAULT 'local',
+ADD COLUMN IF NOT EXISTS storage_bucket TEXT,
+ADD COLUMN IF NOT EXISTS storage_key TEXT,
+ADD COLUMN IF NOT EXISTS content_hash TEXT;
+
+-- 添加处理状态字段
+ALTER TABLE documents
+ADD COLUMN IF NOT EXISTS processing_status TEXT DEFAULT 'pending',
+ADD COLUMN IF NOT EXISTS processing_error TEXT,
+ADD COLUMN IF NOT EXISTS retry_count INTEGER DEFAULT 0,
+ADD COLUMN IF NOT EXISTS chunks_count INTEGER DEFAULT 0,
+ADD COLUMN IF NOT EXISTS vectors_count INTEGER DEFAULT 0,
+ADD COLUMN IF NOT EXISTS processing_started_at TIMESTAMP WITH TIME ZONE,
+ADD COLUMN IF NOT EXISTS processing_completed_at TIMESTAMP WITH TIME ZONE;
+
+-- 添加 processing_status CHECK 约束（已存在则跳过）
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE table_name = 'documents'
+      AND constraint_name = 'documents_processing_status_check'
+  ) THEN
+    ALTER TABLE documents
+    ADD CONSTRAINT documents_processing_status_check
+    CHECK (processing_status IN ('pending', 'processing', 'completed', 'failed', 'retrying'));
+  END IF;
+END $$;
+
+-- 创建索引
+CREATE INDEX IF NOT EXISTS idx_documents_storage_key ON documents(storage_key);
+CREATE INDEX IF NOT EXISTS idx_documents_content_hash ON documents(content_hash);
+CREATE INDEX IF NOT EXISTS idx_documents_processing_status ON documents(processing_status);

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -115,6 +115,16 @@ export default defineNuxtConfig({
 
   nitro: {
     preset: process.env.VERCEL ? 'vercel' : 'node-server',
+    serverAssets: [
+      {
+        baseName: 'config',
+        dir: './config'
+      },
+      {
+        baseName: 'migrations',
+        dir: './migrations'
+      }
+    ],
     routeRules: {
       // 向后兼容：将旧版 /api/* 路径 307 重定向到 /api/v1/*
       // 使用 307 Temporary Redirect 保持 HTTP 方法不变（POST 仍为 POST）

--- a/server/plugins/migrate.ts
+++ b/server/plugins/migrate.ts
@@ -1,0 +1,90 @@
+/**
+ * 数据库自动迁移插件
+ * 服务启动时按顺序执行 migrations/ 目录下所有 SQL 迁移文件
+ * 通过 schema_migrations 表记录已执行的迁移，避免重复执行
+ */
+
+import { readFileSync, existsSync } from 'fs'
+import { join } from 'path'
+import { dbClient } from '~/lib/db/client'
+import { dbLogger } from '~/lib/logger'
+
+// 按执行顺序排列的迁移文件列表
+// 新增迁移时，将文件名追加到列表末尾
+const MIGRATIONS = [
+  'add-workspaces-support.sql',
+  'add-workspace-members-invitations.sql',
+  'add-user-data-isolation.sql',
+  'add-user-model-selection.sql',
+  'add_reset_token_fields.sql',
+  'add-audit-logs.sql',
+  'add-assets-tables.sql',
+  'add-prototype-device-type.sql',
+  'add-documents-processing-fields.sql'
+]
+
+async function readMigrationSQL (filename: string): Promise<string> {
+  // 优先尝试从文件系统读取（本地开发 / node-server）
+  const filePath = join(process.cwd(), 'migrations', filename)
+  if (existsSync(filePath)) {
+    return readFileSync(filePath, 'utf-8')
+  }
+  // Vercel 环境：从 serverAssets 读取（nitro.serverAssets 打包的内容）
+  const storage = useStorage('assets:migrations')
+  const content = await storage.getItem<string>(filename)
+  if (!content) {
+    throw new Error(`Migration file not found: ${filename}`)
+  }
+  return content
+}
+
+export default defineNitroPlugin(async () => {
+  // 仅在生产环境或明确开启时执行自动迁移
+  if (process.env.NODE_ENV !== 'production' && !process.env.RUN_MIGRATIONS) {
+    return
+  }
+
+  try {
+    // 确保迁移记录表存在
+    await dbClient.query(`
+      CREATE TABLE IF NOT EXISTS schema_migrations (
+        name TEXT PRIMARY KEY,
+        executed_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+      )
+    `)
+
+    // 查询已执行的迁移
+    const { rows } = await dbClient.query<{ name: string }>(
+      'SELECT name FROM schema_migrations'
+    )
+    const executed = new Set(rows.map(r => r.name))
+
+    // 按顺序执行尚未执行的迁移
+    for (const filename of MIGRATIONS) {
+      if (executed.has(filename)) {
+        continue
+      }
+
+      try {
+        const sql = await readMigrationSQL(filename)
+
+        await dbClient.transaction(async (client) => {
+          await client.query(sql)
+          await client.query(
+            'INSERT INTO schema_migrations (name) VALUES ($1)',
+            [filename]
+          )
+        })
+
+        dbLogger.info({ migration: filename }, 'Migration executed successfully')
+      } catch (err) {
+        dbLogger.error({ err, migration: filename }, 'Migration failed')
+        // 迁移失败不阻止服务启动，但记录错误
+      }
+    }
+
+    dbLogger.info('Database migrations check completed')
+  } catch (err) {
+    dbLogger.error({ err }, 'Failed to run database migrations')
+  }
+})


### PR DESCRIPTION
## Summary

- **修复 ai-models.yaml 缺失**：`ModelManager` 读取 yaml 失败时使用内嵌默认配置，不再抛出 ENOENT 错误
- **静态文件打包**：`nuxt.config.ts` 添加 `nitro.serverAssets`��将 `config/` 和 `migrations/` 目录打包进 Vercel 产物
- **自动迁移插件**：新增 `server/plugins/migrate.ts`，生产环境服务启动时自动执行未完成的 SQL 迁移，通过 `schema_migrations` 表防止重复执行
- **补充迁移文件**：新增 `migrations/add-documents-processing-fields.sql`，包含 `processing_error` 等字段（已通过脚本在生产库手动执行）

## Test plan

- [ ] 部署到 Vercel 后上传文件不再报 `ENOENT: no such file or directory, open '/var/task/config/ai-models.yaml'`
- [ ] Vercel 日志中可见 `Database migrations check completed`
- [ ] 未来新增迁移文件时，只需将文件名追加到 `MIGRATIONS` 数组末尾，下次部署自动执行

🤖 Generated with [Claude Code](https://claude.com/claude-code)