### PR TITLE
fix: resolve upload SSE failure and improve document UX

### DIFF
--- a/components/documents/DocumentList.vue
+++ b/components/documents/DocumentList.vue
@@ -25,7 +25,7 @@
       >
         <CardContent class="p-4">
           <div class="flex items-center justify-between">
-            <div class="flex items-center space-x-3 flex-1">
+            <div class="flex items-center space-x-3 flex-1 min-w-0">
               <component :is="getFileIcon(doc.fileType)" class="w-8 h-8 text-primary flex-shrink-0" />
               <div class="flex-1 min-w-0">
                 <h4 class="font-semibold truncate">
@@ -36,7 +36,10 @@
                 </p>
               </div>
             </div>
-            <div class="flex items-center space-x-2">
+            <div class="flex items-center space-x-2 flex-shrink-0">
+              <Badge :variant="getStatusVariant(doc.processingStatus)" class="text-xs">
+                {{ $t(getStatusKey(doc.processingStatus)) }}
+              </Badge>
               <span class="text-sm text-muted-foreground">{{ formatFileSize(doc.fileSize) }}</span>
               <Button
                 variant="ghost"
@@ -93,11 +96,31 @@ function formatFileSize (bytes: number) {
 }
 
 function getOriginalFileName (doc: Document) {
-  // 优先从 metadata 获取原始文件名
   if (doc.metadata?.originalFileName) {
     return doc.metadata.originalFileName
   }
-  // 降级方案:从 filePath 提取文件名
   return doc.filePath.split('/').pop() || doc.title
+}
+
+function getStatusVariant (status?: string): 'default' | 'secondary' | 'destructive' | 'outline' {
+  switch (status) {
+    case 'completed': return 'default'
+    case 'processing':
+    case 'pending':
+    case 'retrying': return 'secondary'
+    case 'failed': return 'destructive'
+    default: return 'outline'
+  }
+}
+
+function getStatusKey (status?: string): string {
+  switch (status) {
+    case 'completed': return 'documents.status.indexed'
+    case 'processing': return 'documents.status.processing'
+    case 'pending': return 'documents.status.pending'
+    case 'retrying': return 'documents.status.retrying'
+    case 'failed': return 'documents.status.failed'
+    default: return 'documents.status.pending'
+  }
 }
 </script>

--- a/lang/en.json
+++ b/lang/en.json
@@ -403,6 +403,13 @@
         "reindex": "Re-index",
         "delete": "Delete"
       }
+    },
+    "status": {
+      "indexed": "Indexed",
+      "processing": "Indexing",
+      "pending": "Pending",
+      "retrying": "Retrying",
+      "failed": "Index Failed"
     }
   },
   "settings": {

--- a/lang/zh-CN.json
+++ b/lang/zh-CN.json
@@ -403,6 +403,13 @@
         "reindex": "重新索引",
         "delete": "删除"
       }
+    },
+    "status": {
+      "indexed": "已索引",
+      "processing": "索引中",
+      "pending": "待索引",
+      "retrying": "重试中",
+      "failed": "索引失败"
     }
   },
   "settings": {


### PR DESCRIPTION
## Summary

- **核心修复**：`document-processing.ts` 读取 `ai-models.yaml` 时新增 serverAssets 降级路径，解决 Vercel 环境下 `ENOENT` 错误导致文档处理失败、events SSE 接口 500 的根本原因
- **上传流程优化**：上传成功后立即 `emit('uploaded')`，RAG 向量化在后台进行，不再阻塞对话框关闭
- **交互修复**：drop zone 改为 `@click.self`，防止点击子元素（Progress、文字）时意外触发 file picker 或弹框
- **文档列表**：每条文档新增索引状态 badge（已索引 / 索引中 / 待索引 / 索引失败）
- **i18n**：新增 `documents.status.*` 翻译 key（zh-CN + en）

## Test plan

- [ ] 上传文档后对话框正常关闭，文档列表立即刷新
- [ ] 文档列表中可见"待索引"→"索引中"→"已索引"状态变化（需刷新列表）
- [ ] Vercel 日志中不再出现 `ENOENT: ai-models.yaml` 错误
- [ ] events SSE 接口不再返回 500
- [ ] 点击 drop zone 空白区域正常唤起文件选择器，点击文字/图标不会二次触发

🤖 Generated with [Claude Code](https://claude.com/claude-code)