### PR TITLE
fix: use fileURLToPath for serverAssets dir paths to resolve Vercel deployment

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,4 +1,6 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
+import { fileURLToPath, URL } from 'node:url'
+
 export default defineNuxtConfig({
   devtools: { enabled: true },
 
@@ -118,11 +120,11 @@ export default defineNuxtConfig({
     serverAssets: [
       {
         baseName: 'config',
-        dir: './config'
+        dir: fileURLToPath(new URL('./config', import.meta.url))
       },
       {
         baseName: 'migrations',
-        dir: './migrations'
+        dir: fileURLToPath(new URL('./migrations', import.meta.url))
       }
     ],
     routeRules: {


### PR DESCRIPTION
## Summary

- 将 `nuxt.config.ts` 中 `serverAssets` 的 `config` 和 `migrations` 目录路径从相对路径改为使用 `fileURLToPath + new URL()` 的绝对路径，修复 Vercel 部署时找不到资源文件的问题

## Test plan

- [ ] 本地 `pnpm dev` 正常运行
- [ ] Vercel 部署后 serverAssets 路径正确解析

🤖 Generated with [Claude Code](https://claude.com/claude-code)