### PR TITLE
ci: skip CI on docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,24 @@ name: CI
 on:
   push:
     branches: [main, develop]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
+      - 'CHANGELOG.md'
+      - 'CONTRIBUTING.md'
+      - 'LICENSE'
   pull_request:
     branches: [main, develop]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
+      - 'CHANGELOG.md'
+      - 'CONTRIBUTING.md'
+      - 'LICENSE'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

- 为 CI workflow 的 `push` 和 `pull_request` 触发器添加 `paths-ignore` 规则
- 以下文件变更不再触发构建与部署：`**.md`、`docs/**`、`CHANGELOG.md`、`CONTRIBUTING.md`、`LICENSE`、`.github/ISSUE_TEMPLATE/**`

## 效果

纯文档更新（如修改 README、CHANGELOG、docs/ 下的文档）push 后不会触发 lint → test → build → deploy 流程，节省 CI 资源。

## Test plan

- [ ] 合并后修改任意 `.md` 文件并 push 到 develop，确认 GitHub Actions 不触发 CI
- [ ] 修改代码文件并 push，确认 CI 正常触发

🤖 Generated with [Claude Code](https://claude.com/claude-code)