### PR TITLE
chore: sync main into develop and fix eslint ignores

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,6 +11,7 @@ export default [
       '.nuxt',
       'dist',
       '.output',
+      '.vercel',
       'build',
       'coverage'
     ]


### PR DESCRIPTION
## Summary

- 将 main 分支的历史提交同步回 develop（包含 PR #33~#38 的内容）
- 修复 eslint.config.js 未忽略 `.vercel/` 构建产物目录导致的 lint 误报

## Changes

- `chore: sync main into develop` — 合并 main 分支历史（7 个提交）至 develop
- `chore: add .vercel to eslint ignores` — 在 `ignores` 列表中添加 `.vercel`，避免扫描 Vercel 构建产物

## Test plan

- [ ] CI lint 检查通过（`.vercel/` 不再被 ESLint 扫描）
- [ ] CI typecheck 通过
- [ ] CI 单元测试通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)