### PR TITLE
docs: update WIKI and deployment checklist for v0.6.0

### DIFF
--- a/docs/DEPLOYMENT_CHECKLIST.md
+++ b/docs/DEPLOYMENT_CHECKLIST.md
@@ -58,8 +58,9 @@ psql $DATABASE_URL -c "SELECT COUNT(*) FROM prd_documents;"
 
 ### 2.1 CI/CD 状态
 
-- [ ] 所有 CI 检查通过（Lint, TypeCheck, Tests, Build, Schema Check）
-- [ ] 测试覆盖率 ≥ 85%
+- [ ] 所有 CI 检查通过（Lint, TypeCheck, Unit Tests, E2E Tests, Build, Schema Check）
+- [ ] 单元测试覆盖率 ≥ 85%
+- [ ] E2E 测试通过（`pnpm test:e2e`，至少无 fail，flaky 可接受）
 - [ ] 无高危安全漏洞（Security Audit）
 - [ ] Docker 镜像构建成功（如适用）
 
@@ -173,14 +174,15 @@ curl https://your-domain.com/api/v1/health
 ### 6.1 健康检查
 
 ```bash
-# 1. API 健康检查
-curl https://your-domain.com/api/v1/health
+# 1. API 健康检查（含 DB 连通性）
+npx vercel curl /api/v1/health --deployment <deployment-url>
+# 预期: {"status":"ok","message":"ArchMind API 正在运行","timestamp":"..."}
 
 # 2. 数据库连接
 psql $DATABASE_URL -c "SELECT version();"
 
-# 3. 存储服务
-pnpm storage:health
+# 3. pgvector 扩展
+psql $DATABASE_URL -c "SELECT extname, extversion FROM pg_extension WHERE extname='vector';"
 ```
 
 ### 6.2 数据完整性
@@ -189,11 +191,19 @@ pnpm storage:health
 # 运行审计脚本
 psql $DATABASE_URL < scripts/audit-production-schema.sql
 
-# 预期输出：
-# ✅ search_vector 列存在
-# ✅ parent_id 列存在
-# ✅ 所有关键表存在
-# ✅ 所有索引存在
+# 检查脏数据（workspace_id 为 NULL 的记录）
+psql $DATABASE_URL -c "SELECT COUNT(*) FROM prd_documents WHERE workspace_id IS NULL;"
+psql $DATABASE_URL -c "SELECT COUNT(*) FROM documents WHERE workspace_id IS NULL;"
+# 预期: 均为 0
+
+# 检查核心表行数一致性
+psql $DATABASE_URL -c "
+  SELECT 'users' t, COUNT(*) n FROM users
+  UNION ALL SELECT 'workspaces', COUNT(*) FROM workspaces
+  UNION ALL SELECT 'workspace_members', COUNT(*) FROM workspace_members
+  ORDER BY t;
+"
+# 预期: users 行数 = workspaces 行数 = workspace_members 行数（每用户一个 owner 工作区）
 ```
 
 ---
@@ -340,4 +350,4 @@ git push
 
 ---
 
-*最后更新: 2026-03-02*
+*最后更新: 2026-03-09*

--- a/docs/WIKI.md
+++ b/docs/WIKI.md
@@ -77,6 +77,8 @@
 | | 头像上传 | ✅ 已实现 |
 | **工作区** | 多工作区隔离 | ✅ 已实现 |
 | | 工作区成员管理 | ✅ 已实现 |
+| | RBAC 权限系统（owner/admin/editor/viewer）| ✅ 已实现 |
+| | 批量导出/导入 | ✅ 已实现 |
 | **AI 配置** | 用户自定义 API Key | ✅ 已实现 |
 | | 多提供商配置 | ✅ 已实现 |
 | | 用户自选模型列表 | ✅ 已实现 |
@@ -91,6 +93,14 @@
 | | 投递日志 | ✅ 已实现 |
 | **国际化** | 中英文双语 | ✅ 已实现 |
 | | 浏览器语言自动切换 | ✅ 已实现 |
+| **新用户引导** | Onboarding 欢迎流程 | ✅ 已实现 |
+| | Setup Wizard（AI Key 配置）| ✅ 已实现 |
+| **体验优化** | 统一骨架屏/Loading 状态 | ✅ 已实现 |
+| | 完善错误页（404/500/403）| ✅ 已实现 |
+| | 移动端响应式适配 | ✅ 已实现 |
+| **质量保障** | E2E 测试（Playwright）| ✅ 已实现 |
+| | 数据库迁移回滚支持 | ✅ 已实现 |
+| | 深度健康检查 | ✅ 已实现 |
 
 ### 1.4 产品指标
 
@@ -99,9 +109,11 @@
 | 批量上传速度 | 10 文件 (5MB) / 8 秒 | < 5 秒 |
 | 混合搜索响应时间 | < 2 秒 (1000 文档) | < 1 秒 |
 | 搜索准确率提升 | +20% (vs 单一模式) | +30% |
-| 测试覆盖率 | ~89% | 95% |
+| 单元测试覆盖率 | ~89% | 95% |
+| E2E 测试 | ✅ Playwright 基础设施已建立 | 核心流程全覆盖 |
 | API 端点数 | 111 个 | - |
-| Vue 组件数 | 181+ | - |
+| Vue 组件数 | 209+ | - |
+| 当前版本 | v0.6.0 | - |
 
 ---
 
@@ -1758,13 +1770,16 @@ export const documentDAO = new DocumentDAO()
 
 ### 16.1 测试框架配置
 
-- **框架**：Vitest ^4.0.18
+- **单元测试框架**：Vitest ^4.0.18
+- **E2E 测试框架**：Playwright（@playwright/test）
 - **DOM 环境**：happy-dom
 - **组件测试**：@vue/test-utils
 - **Mock**：msw (Mock Service Worker)
 - **覆盖率**：@vitest/coverage-v8
 
 ### 16.2 当前测试覆盖
+
+#### 单元测试（~89% 覆盖率）
 
 | 测试文件 | 覆盖内容 |
 |----------|----------|
@@ -1776,15 +1791,28 @@ export const documentDAO = new DocumentDAO()
 | `tests/unit/lib/db/dao/document-dao.test.ts` | 文档 DAO 的 CRUD 操作 |
 | `tests/unit/composables/useAiModels.test.ts` | AI 模型 Composable |
 
-**当前覆盖率：~15%（目标：80%）**
+#### E2E 测试（Playwright）
+
+| 测试文件 | 覆盖内容 | CI 状态 |
+|----------|----------|---------|
+| `tests/e2e/auth.spec.ts` | 未登录重定向保护 | ✅ 运行 |
+| `tests/e2e/auth.spec.ts` | 注册/登录/登出完整流程 | ⏸ 跳过（需完整后端环境） |
+| `tests/e2e/documents.spec.ts` | 文档上传与管理 | ⏸ 跳过（需 DB seed） |
+| `tests/e2e/prd.spec.ts` | PRD 生成流程 | ⏸ 跳过（需 DB seed） |
+| `tests/e2e/workspace.spec.ts` | 工作区管理 | ⏸ 跳过（需 DB seed） |
+| `tests/e2e/onboarding.spec.ts` | 新用户引导流程 | ⏸ 跳过（需 DB seed） |
+
+> **注**：跳过的测试待 seed 机制完善后启用，当前 CI 只运行不依赖后端状态的测试。
 
 ### 16.3 测试命令
 
 ```bash
-pnpm test              # 运行所有测试
+pnpm test              # 运行所有单元测试
 pnpm test:watch        # 监听模式
 pnpm test:coverage     # 生成覆盖率报告
 pnpm test:ui           # Vitest UI 界面
+pnpm test:e2e          # 运行 E2E 测试（需先启动开发服务器）
+pnpm test:e2e:ui       # Playwright UI 模式
 ```
 
 ### 16.4 测试最佳实践
@@ -1876,9 +1904,8 @@ DATABASE_POOL_MAX=10  # 最大连接数（生产环境建议 20）
 
 ## 18. 项目路线图
 
-### v0.1.0 (当前 - 2026-02-16)
+### v0.1.0 (已发布 ✅ - 2026-02-16)
 
-**已完成的核心功能**：
 - 文档管理（上传、版本控制、批量操作、去重）
 - RAG 引擎（向量搜索、全文搜索、混合搜索）
 - PRD 生成（对话式、流式、多模型）
@@ -1893,7 +1920,6 @@ DATABASE_POOL_MAX=10  # 最大连接数（生产环境建议 20）
 
 ### v0.2.0 (已发布 ✅)
 
-**新增**：
 - Redis 缓存层（减少 AI API 重复调用）
 - Rate Limiting（防止 API 滥用）
 - CSRF 保护
@@ -1903,7 +1929,6 @@ DATABASE_POOL_MAX=10  # 最大连接数（生产环境建议 20）
 
 ### v0.3.0 (已发布 ✅)
 
-**新增**：
 - WebSocket 实时通信（Nitro 原生，HttpOnly Cookie 服务端鉴权）
 - 团队协作（评论系统、活动日志、成员在线状态）
 - Webhook 支持（HMAC-SHA256 签名，事件订阅，投递日志）
@@ -1911,22 +1936,56 @@ DATABASE_POOL_MAX=10  # 最大连接数（生产环境建议 20）
 - Docker 生产配置（资源限制、Nginx WebSocket 代理、AOF 持久化）
 - 国际化完善（中英文双语，浏览器语言自动切换）
 
-**安全修复（Review）**：
-- WebSocket Cookie 鉴权修复（Critical）
-- 迁移文件 UUID 类型修复（High）
-- 评论权限加固（High）
-- Webhook Header 顺序修复（High）
-- Docker 弱密码移除（Medium）
-- 注册事务原子性（Medium）
+### v0.4.0 (已发布 ✅)
+
+- Few-shot 示例库扩展
+- 语义感知上下文压缩
+- PRD 质量维度扩��
+- PRD 用户反馈打分
+- 原型多页面解析容错
+- 原型主题定制（ThemeConfig + THEME_PRESETS）
+- JS 模板库（按原型类型自动注入）
+- RAG 动态阈值
+- RAG 检索质量面板
+- Webhook 前端管理
+- PRD 多版本对比（prd_snapshots 表，Git 风格两层版本管理）
+
+### v0.5.0 (已发布 ✅)
+
+- RBAC 权限系统（owner/admin/editor/viewer/guest）
+- 批量导出/导入（Word、PDF）
+- 数据导出（工作区级别）
+- 工作区权限覆盖（workspace_permission_overrides）
+
+### v0.6.0 (已发布 ✅ - 2026-03-09)
+
+- 新用户引导（Onboarding 欢迎流程 + Setup Wizard）
+- 完善错误页（404/500/403）
+- 统一 Loading/骨架屏设计
+- E2E 测试基础设施（Playwright，CI 集成）
+- 深度健康检查（DB/pgvector/存储连通性）
+- 数据库迁移回滚支持（migration_history 表）
+- 移动端响应式基础适配
+
+### v0.7.0 (计划中)
+
+- 插件系统 MVP（第三方集成 API 规范）
+- Kubernetes 部署配置
+- E2E 测试 seed 机制（完善登录态测试）
+
+### v0.8.0 (计划中)
+
+- 性能测试基准（实测 P50/P99 数据）
+- 安全审计
+- 移动端深度适配
 
 ### v1.0.0 (计划中)
 
-**新增**：
-- RBAC 权限系统（管理员、成员、访客）
-- 批量导出/导入（Word、PDF）
-- 插件系统（第三方集成）
-- Kubernetes 部署配置
-- 多租户 SaaS 模式支持
+- 一键安装脚本（`install.sh`，自动检测环境）
+- Docker 官方镜像发布（DockerHub/GHCR）
+- 升级脚本（v0.x → v1.0 自动数据迁移）
+- 用户手册（面向非技术用户）
+- API 稳定性声明（1.0 后向后兼容范围）
 
 ---
 
@@ -1941,6 +2000,8 @@ DATABASE_POOL_MAX=10  # 最大连接数（生产环境建议 20）
 | 邮件配置硬编码 QQ SMTP | 不灵活 | 低优先级 |
 | 缺少 CSRF Token 前端注入 | 当前采用 Origin/Referer 校验，未实现 Token 模式 | 低优先级 |
 | Redis 缓存为可选 | 未配置 REDIS_URL 时降级为内存缓存，重启后失效 | 已知，生产环境建议配置 Redis |
+| workspaces.name 全局唯一约束 | 两个用户若工作区同名会注册失败 | 低风险，计划改为 (name, owner_id) 联合唯一 |
+| E2E 测试 flaky（重定向保护）| CI 中偶发超时（10s 不够），重试后通过 | 低优先级，可调大超时 |
 
 ### 19.2 数据安全注意事项
 
@@ -1975,6 +2036,6 @@ DATABASE_POOL_MAX=10  # 最大连接数（生产环境建议 20）
 
 ---
 
-*最后更新：2026-02-28 | 版本：0.3.0*
+*最后更新：2026-03-09 | 版本：0.6.0*
 
 *ArchMind AI - 让每一份历史文档都成为新功能的基础*

--- a/docs/dev/v0.6.0-design.md
+++ b/docs/dev/v0.6.0-design.md
@@ -1,0 +1,862 @@
+# ArchMind v0.6.0 开发设计文档
+
+> 基于需求文档 v1.0 编写
+> 文档版本：v1.0
+> 创建日期：2026-03-08
+> 状态：已定稿
+
+---
+
+## 一、总体设计原则
+
+| 原则 | 说明 |
+|------|------|
+| **最小侵入** | Onboarding 以覆盖层/引导状态实现，不修改现有路由结构 |
+| **向后兼容** | 健康检查新增端点，旧端点 `/api/v1/health` 保持响应结构不变 |
+| **异步优先** | Onboarding 状态更新、健康检查子项均并行执行 |
+| **复用优先** | 骨架屏基于现有 `components/ui/skeleton/Skeleton.vue` 封装，不引入新库 |
+| **测试先行** | E2E 测试优先覆盖核心流程，单元测试覆盖率维持 85%+ |
+
+---
+
+## 二、各功能设计详情
+
+---
+
+### #71 新用户 Onboarding 引导流程
+
+#### 改动文件
+
+| 文件 | 操作 | 说明 |
+|------|------|------|
+| `lib/db/schema.ts` | 修改 | `users` 表新增 `onboardingState` JSONB 字段 |
+| `lib/db/dao/user-dao.ts` | 修改 | 新增 `getOnboardingState()` / `updateOnboardingState()` |
+| `server/api/v1/users/me/onboarding.get.ts` | 新增 | 获取引导状态 |
+| `server/api/v1/users/me/onboarding.patch.ts` | 新增 | 更新引导状态 |
+| `composables/useOnboarding.ts` | 新增 | Onboarding 状态管理 Composable |
+| `components/onboarding/WelcomeScreen.vue` | 新增 | 欢迎页面（覆盖层） |
+| `components/onboarding/SetupWizard.vue` | 新增 | Setup Wizard 多步 Dialog |
+| `components/onboarding/EmptyStateDocument.vue` | 新增 | 文档页空状态 |
+| `components/onboarding/EmptyStatePRD.vue` | 新增 | PRD 页空状态 |
+| `pages/app.vue` | 修改 | 集成 WelcomeScreen + 替换现有空状态 |
+| `pages/knowledge-base.vue` | 修改 | 替换空状态为 EmptyStateDocument |
+| `pages/generate.vue` | 修改 | 替换空状态为 EmptyStatePRD |
+| `migrations/v0.6.0_add-onboarding-state.up.sql` | 新增 | 正向迁移 |
+| `migrations/v0.6.0_add-onboarding-state.down.sql` | 新增 | 回滚迁移 |
+| `tests/unit/composables/useOnboarding.test.ts` | 新增 | 单元测试 |
+
+#### 数据结构
+
+**`users` 表新增字段**：
+
+```sql
+-- v0.6.0_add-onboarding-state.up.sql
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS onboarding_state JSONB NOT NULL DEFAULT '{}';
+```
+
+**`OnboardingState` 类型定义**（`types/onboarding.ts`，新增）：
+
+```typescript
+export interface OnboardingState {
+  hasConfiguredAI: boolean      // 是否配置过 AI Key（POST /api/v1/ai/configs/validate 成功过）
+  hasUploadedDocument: boolean  // 是否上传过文档（documents 表有记录）
+  hasGeneratedPRD: boolean      // 是否生成过 PRD（prd_documents 表有记录）
+  skipped: boolean              // 用户主动跳过引导
+  completedAt?: string          // 所有步骤完成时间（ISO 8601）
+}
+```
+
+#### Composable 设计（`composables/useOnboarding.ts`）
+
+```typescript
+export function useOnboarding() {
+  const state = ref<OnboardingState>({
+    hasConfiguredAI: false,
+    hasUploadedDocument: false,
+    hasGeneratedPRD: false,
+    skipped: false,
+  })
+  const isLoading = ref(false)
+
+  // 判断是否需要显示 WelcomeScreen
+  // 条件：未跳过 + 未完成 + 注册时间在 v0.6.0 发布日之后
+  const shouldShowWelcome = computed(() =>
+    !state.value.skipped &&
+    !state.value.completedAt &&
+    !state.value.hasGeneratedPRD
+  )
+
+  // 判断当前完成步骤数（用于进度指示）
+  const completedSteps = computed(() => [
+    state.value.hasConfiguredAI,
+    state.value.hasUploadedDocument,
+    state.value.hasGeneratedPRD,
+  ].filter(Boolean).length)
+
+  async function fetchState() { ... }
+  async function markStep(step: keyof OnboardingState, value: boolean) { ... }
+  async function skipOnboarding() { ... }
+
+  return { state, isLoading, shouldShowWelcome, completedSteps, fetchState, markStep, skipOnboarding }
+}
+```
+
+#### WelcomeScreen 交互逻辑
+
+`WelcomeScreen.vue` 以绝对定位覆盖层呈现（`z-50`），仅在 `shouldShowWelcome = true` 时展示。
+点击"立即开始"→ 打开 `SetupWizard.vue` Dialog；点击"跳过引导"→ 调用 `skipOnboarding()`，WelcomeScreen 消失。
+
+**SetupWizard 步骤**（3 步）：
+
+| 步骤 | 内容 | 完成动作 |
+|------|------|---------|
+| 1 | 选择 AI 提供商（8 个卡片） | 选中后激活"下一步" |
+| 2 | 输入 API Key + 测试连接（内嵌验证表单，调用 `/api/v1/ai/configs/validate`） | 验证通过 → `markStep('hasConfiguredAI', true)` |
+| 3 | 完成提示 + 快捷入口（上传文档 / 生成 PRD 按钮） | 关闭 Wizard |
+
+#### 空状态组件规范
+
+**EmptyStateDocument.vue**：
+- 插画（SVG，文档图形）
+- 标题："上传你的第一份文档"
+- 描述："支持 PDF、DOCX、Markdown 格式"
+- 操作按钮：`<Button>` 打开上传 Dialog
+
+**EmptyStatePRD.vue**：
+- 插画（SVG，PRD 图形）
+- 标题："还没有 PRD？"
+- 描述："上传历史文档后，AI 帮你生成产品需求文档"
+- 操作按钮：`<NuxtLink to="/knowledge-base">` 跳转文档页
+
+#### API 端点
+
+**GET `/api/v1/users/me/onboarding`**：
+
+```typescript
+// 响应
+{ success: true, data: OnboardingState }
+```
+
+若 `onboarding_state` 为 `{}`（历史用户）：
+- 查询该用户是否有文档、PRD 记录，动态计算并返回 `hasUploadedDocument`/`hasGeneratedPRD`
+- 同时将 `skipped: true` 写入（历史用户自动跳过引导，不显示 Welcome Screen）
+
+**PATCH `/api/v1/users/me/onboarding`**：
+
+```typescript
+// 请求体（Zod 校验）
+const Body = z.object({
+  hasConfiguredAI: z.boolean().optional(),
+  hasUploadedDocument: z.boolean().optional(),
+  hasGeneratedPRD: z.boolean().optional(),
+  skipped: z.boolean().optional(),
+})
+```
+
+---
+
+### #72 错误页面（404 / 500 / 403）
+
+#### 改动文件
+
+| 文件 | 操作 | 说明 |
+|------|------|------|
+| `error.vue` | 新增（根目录）| Nuxt 3 全局错误页入口 |
+| `components/error/ErrorIllustration.vue` | 新增 | 错误类型 SVG 插画 |
+| `components/error/ErrorActions.vue` | 新增 | 操作按钮组 |
+| `pages/403.vue` | 新增 | 403 专用页面 |
+
+#### 实现方式
+
+**Nuxt 3 错误处理机制**：
+
+根目录 `error.vue` 捕获所有未处理错误（客户端路由 404、SSR 错误等）。通过 `useError()` 获取错误对象：
+
+```vue
+<!-- error.vue -->
+<script setup lang="ts">
+const error = useError()
+const statusCode = computed(() => error.value?.statusCode ?? 500)
+
+// 映射错误码到显示配置
+const errorConfig = computed(() => {
+  switch (statusCode.value) {
+    case 404: return { title: '页面不存在', desc: '你访问的页面已删除或从未存在', action: '返回首页', href: '/app' }
+    case 403: return { title: '没有访问权限', desc: '你没有权限访问此资源', action: '返回工作区', href: '/app' }
+    default:  return { title: '服务出现问题', desc: '我们正在修复，请稍后再试', action: '刷新重试', href: null }
+  }
+})
+
+// 500 时展示 reqId（从 error.data 中提取，由后端注入）
+const reqId = computed(() => (error.value as any)?.data?.reqId ?? null)
+</script>
+```
+
+**403 页面触发方式**：
+
+前端接收到 API 403 响应时，通过 `navigateTo('/403')` 跳转。后端中间件 403 响应需在错误 body 中附加 `reqId`：
+
+```typescript
+// server/utils/auth-helpers.ts 修改
+throw createError({
+  statusCode: 403,
+  statusMessage: 'Forbidden',
+  data: { reqId: event.context.reqId }  // 从 logger 中间件注入的 reqId
+})
+```
+
+#### ErrorIllustration 组件
+
+```vue
+<!-- components/error/ErrorIllustration.vue -->
+<script setup lang="ts">
+defineProps<{ code: 404 | 403 | 500 }>()
+</script>
+<template>
+  <!-- 根据 code prop 切换 SVG 内容 -->
+  <div class="w-48 h-48 mx-auto">
+    <svg v-if="code === 404" .../>
+    <svg v-else-if="code === 403" .../>
+    <svg v-else .../>
+  </div>
+</template>
+```
+
+---
+
+### #73 Loading 状态与骨架屏统一
+
+#### 改动文件
+
+| 文件 | 操作 | 说明 |
+|------|------|------|
+| `components/ui/skeleton/SkeletonCard.vue` | 新增 | 卡片骨架 |
+| `components/ui/skeleton/SkeletonList.vue` | 新增 | 列表骨架（接受 `count` prop） |
+| `components/ui/skeleton/SkeletonDetail.vue` | 新增 | 详情页骨架 |
+| `components/ui/skeleton/SkeletonTable.vue` | 新增 | 表格骨架 |
+| `components/ui/skeleton/SkeletonSidebar.vue` | 新增 | 侧边栏骨架 |
+| `plugins/nprogress.client.ts` | 新增 | 顶部路由进度条 |
+| `pages/app.vue` | 修改 | `loading` 时替换为 `SkeletonList` |
+| `pages/knowledge-base.vue` | 修改 | 同上 |
+| `pages/generate.vue` | 修改 | 同上 |
+| `pages/prototypes.vue` | 修改 | 同上 |
+| `pages/documents/[id].vue` | 修改 | 替换为 `SkeletonDetail` |
+| `pages/projects/[id].vue` | 修改 | 替换为 `SkeletonDetail` |
+| `components/AppSidebar.vue` | 修改 | 工作区数据加载中时替换为 `SkeletonSidebar` |
+
+#### 骨架屏组件规范
+
+**SkeletonCard.vue**（用于文档/PRD 列表项）：
+
+```vue
+<template>
+  <div class="rounded-lg border border-border p-4 space-y-3">
+    <Skeleton class="h-5 w-3/4" />          <!-- 标题 -->
+    <Skeleton class="h-4 w-full" />          <!-- 描述行 1 -->
+    <Skeleton class="h-4 w-2/3" />           <!-- 描述行 2 -->
+    <div class="flex gap-2 pt-1">
+      <Skeleton class="h-5 w-16 rounded-full" />  <!-- Badge -->
+      <Skeleton class="h-5 w-20 rounded-full" />  <!-- Badge -->
+    </div>
+  </div>
+</template>
+```
+
+**SkeletonList.vue**：
+
+```vue
+<script setup lang="ts">
+defineProps<{ count?: number }>()
+const _count = computed(() => props.count ?? 6)
+</script>
+<template>
+  <div :class="gridClass">
+    <SkeletonCard v-for="i in _count" :key="i" />
+  </div>
+</template>
+```
+
+**SkeletonDetail.vue**（PRD/文档详情）：
+
+```vue
+<template>
+  <div class="space-y-6">
+    <Skeleton class="h-8 w-2/3" />          <!-- 大标题 -->
+    <div class="flex gap-2">
+      <Skeleton class="h-6 w-24 rounded-full" />
+      <Skeleton class="h-6 w-16 rounded-full" />
+    </div>
+    <div class="space-y-3">
+      <Skeleton class="h-4 w-full" v-for="i in 8" :key="i" />
+    </div>
+  </div>
+</template>
+```
+
+#### 页面改造规范
+
+**统一替换模式**（以 `pages/app.vue` 为例）：
+
+```vue
+<!-- 改造前 -->
+<div v-if="loading" class="flex items-center justify-center py-12">
+  <RefreshCw class="w-8 h-8 animate-spin text-muted-foreground" />
+</div>
+
+<!-- 改造后 -->
+<SkeletonList v-if="loading" :count="9" />
+```
+
+#### 顶部进度条（nprogress）
+
+**安装**：`pnpm add nprogress`（轻量，3KB）
+
+**`plugins/nprogress.client.ts`**：
+
+```typescript
+import NProgress from 'nprogress'
+import 'nprogress/nprogress.css'
+
+NProgress.configure({ showSpinner: false, trickleSpeed: 200 })
+
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.hooks.hook('page:start', () => NProgress.start())
+  nuxtApp.hooks.hook('page:finish', () => NProgress.done())
+  nuxtApp.hooks.hook('page:error', () => NProgress.done())
+})
+```
+
+**样式覆盖**（`assets/css/main.css` 追加）：
+
+```css
+#nprogress .bar {
+  @apply bg-primary;
+  height: 2px;
+}
+```
+
+---
+
+### #74 E2E 测试补全（核心流程）
+
+#### 改动文件
+
+| 文件 | 操作 | 说明 |
+|------|------|------|
+| `playwright.config.ts` | 新增（根目录）| Playwright 主配置 |
+| `tests/e2e/auth.spec.ts` | 新增 | 认证流程测试 |
+| `tests/e2e/documents.spec.ts` | 新增 | 文档上传流程测试 |
+| `tests/e2e/prd.spec.ts` | 新增 | PRD 生成流程测试 |
+| `tests/e2e/workspace.spec.ts` | 新增 | 工作区管理测试 |
+| `tests/e2e/onboarding.spec.ts` | 新增 | Onboarding 流程测试 |
+| `tests/e2e/fixtures/test-user.ts` | 新增 | 测试用户 fixture |
+| `tests/e2e/helpers/auth.ts` | 新增 | 登录快捷函数 |
+| `.github/workflows/ci.yml` | 修改 | 新增 `e2e` Job |
+| `package.json` | 修改 | 新增 `test:e2e` / `test:e2e:ui` 命令 |
+| `vitest.config.ts` | 修改 | 确认已排除 `tests/e2e/**` |
+
+#### playwright.config.ts
+
+```typescript
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: false,  // E2E 测试串行，避免数据竞争
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? 'github' : 'html',
+  use: {
+    baseURL: process.env.E2E_BASE_URL ?? 'http://localhost:3000',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+  webServer: {
+    command: 'pnpm dev',
+    port: 3000,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+})
+```
+
+#### 核心测试用例设计
+
+**`tests/e2e/auth.spec.ts`（P0）**：
+
+```typescript
+test('用户注册 → 登录 → 登出完整流程', async ({ page }) => {
+  // 1. 访问注册页
+  await page.goto('/register')
+  await page.fill('[data-testid="email"]', `test-${Date.now()}@e2e.test`)
+  await page.fill('[data-testid="password"]', 'Test1234!')
+  await page.click('[data-testid="register-submit"]')
+
+  // 2. 注册成功后跳转到 /app
+  await page.waitForURL('/app')
+  await expect(page.locator('[data-testid="welcome-screen"]')).toBeVisible()
+
+  // 3. 登出
+  await page.click('[data-testid="user-menu"]')
+  await page.click('[data-testid="logout"]')
+  await page.waitForURL('/login')
+})
+```
+
+**`tests/e2e/prd.spec.ts`（P0）**：
+
+```typescript
+test('选择模板 → 填写需求 → PRD 流式生成 → 保存', async ({ page }) => {
+  await loginAsTestUser(page)  // helper：已有账号快速登录
+
+  await page.goto('/generate?new=1')
+  // 1. 选择标准模板
+  await page.click('[data-testid="template-standard"]')
+  await page.click('[data-testid="next-step"]')
+
+  // 2. 填写 PRD 需求
+  await page.fill('[data-testid="prd-input"]', '用户登录功能，支持邮箱密码登录')
+  await page.click('[data-testid="generate-prd"]')
+
+  // 3. 等待流式输出完成（最多 60s）
+  await page.waitForSelector('[data-testid="prd-complete"]', { timeout: 60_000 })
+
+  // 4. 验证 PRD 内容非空
+  const content = await page.locator('[data-testid="prd-content"]').textContent()
+  expect(content?.length).toBeGreaterThan(100)
+})
+```
+
+#### CI 集成（`.github/workflows/ci.yml` 新增 Job）
+
+```yaml
+e2e:
+  name: E2E Tests
+  needs: [lint, unit-test]
+  runs-on: ubuntu-latest
+  services:
+    postgres:
+      image: pgvector/pgvector:pg14
+      env:
+        POSTGRES_DB: archmind_test
+        POSTGRES_USER: postgres
+        POSTGRES_PASSWORD: postgres
+      ports: ['5432:5432']
+      options: >-
+        --health-cmd pg_isready
+        --health-interval 10s
+        --health-timeout 5s
+        --health-retries 5
+  env:
+    DATABASE_URL: postgresql://postgres:postgres@localhost:5432/archmind_test
+    JWT_SECRET: e2e-test-secret-32-chars-min-len
+    E2E_BASE_URL: http://localhost:3000
+  steps:
+    - uses: actions/checkout@v4
+    - uses: pnpm/action-setup@v4
+    - uses: actions/setup-node@v4
+      with: { node-version: '20', cache: 'pnpm' }
+    - run: pnpm install
+    - run: pnpm exec playwright install --with-deps chromium
+    - run: pnpm db:init
+    - run: pnpm test:e2e --project=chromium
+    - uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 7
+```
+
+#### data-testid 约定
+
+所有 E2E 关键元素需添加 `data-testid` 属性（不影响生产用户，仅用于测试定位）：
+
+| 元素 | data-testid |
+|------|-------------|
+| 欢迎页容器 | `welcome-screen` |
+| 注册表单 email | `email` |
+| 注册提交按钮 | `register-submit` |
+| PRD 需求输入框 | `prd-input` |
+| 生成 PRD 按钮 | `generate-prd` |
+| PRD 生成完成标记 | `prd-complete` |
+
+---
+
+### #75 健康检查深度完善
+
+#### 改动文件
+
+| 文件 | 操作 | 说明 |
+|------|------|------|
+| `server/api/v1/health.get.ts` | 修改 | 增强为深度检查，保持响应向后兼容 |
+| `server/api/v1/health/live.get.ts` | 新增 | Liveness 探针（快速返回 200）|
+| `server/api/v1/health/ready.get.ts` | 新增 | Readiness 探针（深度检查）|
+| `lib/health/checker.ts` | 新增 | 健康检查核心逻辑（复用在两个端点）|
+| `types/health.ts` | 新增 | 类型定义 |
+| `tests/unit/health/checker.test.ts` | 新增 | 单元测试（Mock DB/存储）|
+
+#### 核心实现（`lib/health/checker.ts`）
+
+```typescript
+import { dbClient } from '~/lib/db/client'
+import { storageFactory } from '~/lib/storage/storage-factory'
+
+export interface CheckResult {
+  status: 'ok' | 'error'
+  latencyMs: number
+  error?: string
+}
+
+export interface HealthCheckResult {
+  status: 'healthy' | 'degraded' | 'unhealthy'
+  version: string
+  timestamp: string
+  checks: {
+    database: CheckResult
+    pgvector: CheckResult
+    storage: CheckResult
+    redis?: CheckResult
+  }
+  responseTimeMs: number
+}
+
+async function checkDatabase(): Promise<CheckResult> {
+  const start = Date.now()
+  try {
+    await dbClient.db.execute(sql`SELECT 1`)
+    return { status: 'ok', latencyMs: Date.now() - start }
+  } catch (e) {
+    return { status: 'error', latencyMs: Date.now() - start, error: String(e) }
+  }
+}
+
+async function checkPgVector(): Promise<CheckResult> {
+  const start = Date.now()
+  try {
+    const rows = await dbClient.db.execute(
+      sql`SELECT 1 FROM pg_extension WHERE extname = 'vector'`
+    )
+    if (!rows.rows.length) throw new Error('pgvector extension not installed')
+    return { status: 'ok', latencyMs: Date.now() - start }
+  } catch (e) {
+    return { status: 'error', latencyMs: Date.now() - start, error: String(e) }
+  }
+}
+
+async function checkStorage(): Promise<CheckResult> {
+  const start = Date.now()
+  try {
+    const storage = storageFactory.getStorage()
+    const testKey = `health-check/ping-${Date.now()}`
+    await storage.upload(testKey, Buffer.from('ping'), 'text/plain')
+    await storage.delete(testKey)
+    return { status: 'ok', latencyMs: Date.now() - start }
+  } catch (e) {
+    return { status: 'error', latencyMs: Date.now() - start, error: String(e) }
+  }
+}
+
+export async function runHealthCheck(): Promise<HealthCheckResult> {
+  const globalStart = Date.now()
+
+  // 所有检查并行执行
+  const [database, pgvector, storage] = await Promise.all([
+    withTimeout(checkDatabase(), 3000),
+    withTimeout(checkPgVector(), 3000),
+    withTimeout(checkStorage(), 5000),
+  ])
+
+  const checks = { database, pgvector, storage }
+
+  // 决定整体状态
+  const isUnhealthy = database.status === 'error' || pgvector.status === 'error'
+  const isDegraded = storage.status === 'error'
+
+  return {
+    status: isUnhealthy ? 'unhealthy' : isDegraded ? 'degraded' : 'healthy',
+    version: process.env.npm_package_version ?? 'unknown',
+    timestamp: new Date().toISOString(),
+    checks,
+    responseTimeMs: Date.now() - globalStart,
+  }
+}
+```
+
+#### 端点实现
+
+**`server/api/v1/health/live.get.ts`**（极简，供 Kubernetes liveness 探针）：
+
+```typescript
+export default defineEventHandler(() => ({ status: 'ok' }))
+```
+
+**`server/api/v1/health/ready.get.ts`**：
+
+```typescript
+import { runHealthCheck } from '~/lib/health/checker'
+
+export default defineEventHandler(async (event) => {
+  const result = await runHealthCheck()
+  if (result.status === 'unhealthy') {
+    setResponseStatus(event, 503)
+  }
+  return result
+})
+```
+
+**`server/api/v1/health.get.ts`**（向后兼容，内部复用 `runHealthCheck`）：
+
+```typescript
+// 保留旧响应字段，追加新字段
+export default defineEventHandler(async (event) => {
+  const result = await runHealthCheck()
+  if (result.status === 'unhealthy') setResponseStatus(event, 503)
+  return {
+    // 旧字段保持不变
+    status: result.status === 'healthy' ? 'ok' : 'error',
+    message: result.status === 'healthy' ? 'API is running' : 'Service degraded',
+    timestamp: result.timestamp,
+    // 新增字段
+    details: result,
+  }
+})
+```
+
+---
+
+### #76 数据库迁移回滚支持
+
+#### 改动文件
+
+| 文件 | 操作 | 说明 |
+|------|------|------|
+| `migrations/*.down.sql` | 新增（8 个）| 各迁移文件的回滚版本 |
+| `migrations/v0.6.0_migration-history.up.sql` | 新增 | migration_history 表 |
+| `migrations/v0.6.0_migration-history.down.sql` | 新增 | 回滚迁移历史表 |
+| `scripts/migrate-status.ts` | 新增 | 查看迁移状态 |
+| `scripts/migrate-down.ts` | 新增 | 执行回滚 |
+| `package.json` | 修改 | 新增 `db:migrate-down` / `db:migrate-status` 命令 |
+
+#### 迁移历史表
+
+```sql
+-- migrations/v0.6.0_migration-history.up.sql
+CREATE TABLE IF NOT EXISTS migration_history (
+  id          SERIAL PRIMARY KEY,
+  version     TEXT NOT NULL,
+  filename    TEXT NOT NULL,
+  direction   TEXT NOT NULL CHECK (direction IN ('up', 'down')),
+  executed_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_migration_history_filename ON migration_history(filename);
+```
+
+#### Down 脚本规范（以关键几个为例）
+
+**`migrations/add-prd-snapshots.down.sql`**：
+
+```sql
+-- 回滚：移除 PRD 快照表
+DROP TABLE IF EXISTS prd_snapshots;
+```
+
+**`migrations/add-rbac-roles.down.sql`**：
+
+```sql
+-- 回滚：将 editor/viewer/guest 成员恢复为 member
+UPDATE workspace_members SET role = 'member'
+WHERE role IN ('editor', 'viewer');
+
+DELETE FROM workspace_members WHERE role = 'guest';
+
+-- 注意：PostgreSQL 不支持 DROP VALUE FROM ENUM
+-- 需要重建枚举类型（此操作需要短暂停机）
+ALTER TABLE workspace_members
+  ALTER COLUMN role TYPE TEXT;
+
+DROP TYPE IF EXISTS workspace_role;
+
+CREATE TYPE workspace_role AS ENUM ('owner', 'admin', 'member');
+
+ALTER TABLE workspace_members
+  ALTER COLUMN role TYPE workspace_role
+  USING role::workspace_role;
+```
+
+**`migrations/add-logic-maps.down.sql`**：
+
+```sql
+DROP TABLE IF EXISTS logic_maps;
+```
+
+#### `scripts/migrate-down.ts`
+
+```typescript
+// 用法：pnpm db:migrate-down --steps 1
+//       pnpm db:migrate-down --filename add-prd-snapshots.sql
+
+async function main() {
+  const args = process.argv.slice(2)
+  const steps = parseInt(args[args.indexOf('--steps') + 1] ?? '1')
+
+  // 从 migration_history 查询最近 N 次 up 迁移
+  const history = await db.execute(
+    sql`SELECT filename FROM migration_history
+        WHERE direction = 'up'
+        ORDER BY executed_at DESC
+        LIMIT ${steps}`
+  )
+
+  for (const row of history.rows) {
+    const downFile = row.filename.replace('.up.sql', '.down.sql')
+    const downPath = path.join('migrations', downFile)
+    if (!fs.existsSync(downPath)) {
+      console.warn(`⚠️  No down script for ${row.filename}, skipping`)
+      continue
+    }
+    const sql_content = fs.readFileSync(downPath, 'utf8')
+    await db.execute(sql.raw(sql_content))
+    await db.execute(sql`
+      INSERT INTO migration_history (version, filename, direction)
+      VALUES ('rollback', ${downFile}, 'down')
+    `)
+    console.log(`✅ Rolled back: ${downFile}`)
+  }
+}
+```
+
+---
+
+### #77 移动端响应式基础适配
+
+#### 改动文件
+
+| 文件 | 操作 | 说明 |
+|------|------|------|
+| `components/AppSidebar.vue` | 修改 | 移动端折叠 + Sheet 展开 |
+| `layouts/dashboard.vue` | 修改 | 响应式布局切换 |
+| `layouts/default.vue` | 修改 | 移动端顶部导航精简 |
+| `components/ui/sheet/` | 已有 | 复用 shadcn/ui Sheet 组件 |
+| `composables/useMobile.ts` | 新增 | 移动端断点检测 |
+
+#### useMobile Composable
+
+```typescript
+// composables/useMobile.ts
+export function useMobile() {
+  const isMobile = ref(false)
+
+  onMounted(() => {
+    const mq = window.matchMedia('(max-width: 639px)')
+    isMobile.value = mq.matches
+    mq.addEventListener('change', (e) => { isMobile.value = e.matches })
+  })
+
+  return { isMobile }
+}
+```
+
+#### AppSidebar.vue 改造要点
+
+```vue
+<script setup lang="ts">
+import { Sheet, SheetContent, SheetTrigger } from '~/components/ui/sheet'
+const { isMobile } = useMobile()
+const mobileMenuOpen = ref(false)
+</script>
+
+<template>
+  <!-- 桌面端：固定侧边栏（不变） -->
+  <aside v-if="!isMobile" class="w-60 flex-shrink-0 border-r ...">
+    <SidebarContent />
+  </aside>
+
+  <!-- 移动端：Sheet 抽屉 -->
+  <Sheet v-else v-model:open="mobileMenuOpen">
+    <SheetTrigger as-child>
+      <Button variant="ghost" size="icon" class="sm:hidden">
+        <Menu class="w-5 h-5" />
+      </Button>
+    </SheetTrigger>
+    <SheetContent side="left" class="w-60 p-0">
+      <SidebarContent @navigate="mobileMenuOpen = false" />
+    </SheetContent>
+  </Sheet>
+</template>
+```
+
+#### 响应式 Tailwind 规范
+
+| 场景 | 桌面 class | 移动端 class |
+|------|-----------|-------------|
+| 列表容器 | `grid-cols-3` | `grid-cols-1` |
+| PRD 详情 | `flex flex-row` | `flex flex-col` |
+| 侧边栏 | `w-60 block` | `hidden` |
+| 页面内边距 | `p-6` | `p-4` |
+
+**核心页面改造**（以 `pages/app.vue` 为例）：
+
+```vue
+<!-- 改造前 -->
+<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+
+<!-- 改造后（已有，无需修改；pages/app.vue 已有响应式类） -->
+```
+
+> 注意：`pages/app.vue` 当前已有 `md:grid-cols-2 lg:grid-cols-3`，主要改造集中在侧边栏和 `layouts/dashboard.vue` 的外层布局。
+
+---
+
+## 三、数据库迁移执行顺序
+
+```bash
+# v0.6.0 迁移脚本执行顺序
+psql $DATABASE_URL -f migrations/v0.6.0_migration-history.up.sql  # 先建迁移历史表
+psql $DATABASE_URL -f migrations/v0.6.0_add-onboarding-state.up.sql
+```
+
+---
+
+## 四、测试计划
+
+| 功能 | 测试类型 | 文件 | 关键用例 |
+|------|---------|------|---------|
+| #71 Onboarding | 单元测试 | `tests/unit/composables/useOnboarding.test.ts` | shouldShowWelcome 逻辑、历史用户自动跳过 |
+| #71 Onboarding API | 集成测试 | `tests/unit/server/api/onboarding.test.ts` | GET/PATCH 正常 + 未认证 401 |
+| #72 错误页面 | E2E | `tests/e2e/error-pages.spec.ts` | 访问 /xyz-404、触发 403、500 展示 reqId |
+| #75 健康检查 | 单元测试 | `tests/unit/health/checker.test.ts` | DB 正常返回 healthy、DB 断开返回 unhealthy |
+| #74 E2E | E2E | `tests/e2e/*.spec.ts` | 见功能设计章节 |
+
+---
+
+## 五、依赖变更
+
+| 包 | 操作 | 用途 |
+|----|------|------|
+| `nprogress` | 新增（`pnpm add nprogress`）| 路由切换顶部进度条 |
+| `@types/nprogress` | 新增（`pnpm add -D @types/nprogress`）| TypeScript 类型 |
+| `@playwright/test` | 已在 package.json（`feature/49-e2e-tests`），确认安装 | E2E 测试框架 |
+
+---
+
+## 六、开发分支规划
+
+| Issue | 分支名 | 目标 PR |
+|-------|--------|---------|
+| #71 | `feature/71-onboarding` | → develop |
+| #72 | `feature/72-error-pages` | → develop |
+| #73 | `feature/73-skeleton-loading` | → develop |
+| #74 | `feature/74-e2e-tests` | → develop |
+| #75 | `feature/75-health-check` | → develop |
+| #76 | `feature/76-migration-rollback` | → develop |
+| #77 | `feature/77-mobile-responsive` | → develop |
+
+---
+
+*文档版本：v1.0 | 创建日期：2026-03-08 | 状态：已定稿 | 负责人：ArchMind Team*

--- a/docs/dev/v0.6.0-requirements.md
+++ b/docs/dev/v0.6.0-requirements.md
@@ -1,0 +1,523 @@
+# ArchMind v0.6.0 版本需求文档
+
+> 版本目标：产品质量跃升——新用户体验完善、稳定性加固与移动端基础适配
+>
+> 基线版本：v0.5.0（已发布）
+> 目标版本：v0.6.0
+> 文档状态：已定稿（v1.0）
+> 最后更新：2026-03-08
+
+---
+
+## 一、版本目标
+
+v0.5.0 完成了企业级能力建设（RBAC、批量操作、数据导入/导出、逻辑图谱、PRD 模板系统），但产品在面向新用户时仍存在较大的体验落差：没有引导、没有友好错误页、Loading 状态不统一。v0.6.0 的重心转向**产品质量跃升**，聚焦三个方向：
+
+1. **新用户体验**：Onboarding 引导流程 + Setup Wizard，让首次使用的用户顺畅上手
+2. **稳定性保障**：E2E 测试补全、健康检查深化、数据库迁移回滚策略
+3. **基础体验打磨**：错误页面、骨架屏、移动端响应式基础适配
+
+---
+
+## 二、功能清单
+
+| Issue | 功能名称 | 模块 | 优先级 |
+|-------|----------|------|--------|
+| #71 | 新用户 Onboarding 引导流程 | 用户体验 | P0 |
+| #72 | 错误页面（404 / 500 / 403） | 用户体验 | P0 |
+| #73 | Loading 状态与骨架屏统一 | 用户体验 | P0 |
+| #74 | E2E 测试补全（核心流程）| 测试质量 | P1 |
+| #75 | 健康检查深度完善 | 稳定性 | P1 |
+| #76 | 数据库迁移回滚支持 | 稳定性 | P1 |
+| #77 | 移动端响应式基础适配 | 跨端 | P2 |
+
+> **优先级定义**：P0 = 版本必做；P1 = 强烈建议；P2 = 时间充裕时实现
+
+---
+
+## 三、功能详细说明
+
+---
+
+### #71 新用户 Onboarding 引导流程
+
+**背景**：首次登录 ArchMind 的用户面对空工作区，不知道从哪开始——没有引导说明"先上传文档"、没有 AI Key 配置提示、没有工作区创建向导。这是用户流失的最高风险点。
+
+**目标**：为新注册用户提供渐进式引导体验，在首次使用的关键步骤给出清晰的操作提示和引导，帮助用户在 5 分钟内完成第一次 PRD 生成。
+
+**引导阶段设计**：
+
+```
+阶段 1：注册成功 → 工作区创建向导（已自动创建，展示欢迎页）
+阶段 2：AI 模型配置引导（Setup Wizard：配置 API Key）
+阶段 3：首次上传文档引导（空状态 + 操作提示）
+阶段 4：首次 PRD 生成引导（文档就绪后，提示生成 PRD）
+阶段 5：完成标记（所有关键步骤完成后，引导结束）
+```
+
+**欢迎页（Welcome Screen）**：
+
+注册成功后首次进入 `/app`，若工作区内无文档、无 PRD，显示 Welcome Screen（全屏覆盖，非 Modal）：
+
+```
+┌─────────────────────────────────────────────┐
+│        欢迎使用 ArchMind！                   │
+│                                             │
+│  让历史文档成为新功能的基础                   │
+│  3 步开始你的第一个 PRD                      │
+│                                             │
+│  [1] 配置 AI 模型 ←（未完成时高亮）         │
+│  [2] 上传历史文档                           │
+│  [3] 生成第一份 PRD                         │
+│                                             │
+│         [ 立即开始 ]  [ 跳过引导 ]          │
+└─────────────────────────────────────────────┘
+```
+
+**Setup Wizard（AI Key 配置步骤）**：
+
+点击"立即开始"后进入多步引导 Dialog（3 步）：
+
+1. **选择 AI 提供商**：展示 8 个提供商卡片，用户选择一个
+2. **输入 API Key**：引导跳转至 Profile → Models 设置，或在 Wizard 内嵌配置表单
+3. **验证连接**：一键测试 API Key 是否有效，通过后进入下一步
+
+**空状态引导（Empty State）**：
+
+| 页面 | 空状态内容 |
+|------|-----------|
+| 文档页（无文档）| 插画 + "上传你的第一份文档" + 上传按钮 + 支持格式说明 |
+| PRD 页（无 PRD）| 插画 + "还没有 PRD？去上传文档后生成" + 跳转按钮 |
+| 工作区设置（新）| 引导配置工作区名称、描述、邀请成员 |
+
+**引导进度持久化**：
+
+```typescript
+// 存储在用户表或 localStorage
+interface OnboardingState {
+  hasConfiguredAI: boolean      // 是否配置了 AI Key
+  hasUploadedDocument: boolean  // 是否上传过文档
+  hasGeneratedPRD: boolean      // 是否生成过 PRD
+  skipped: boolean              // 是否跳过引导
+  completedAt?: string          // 完成时间
+}
+```
+
+**数据库变更**：
+
+`users` 表新增字段：
+
+```sql
+ALTER TABLE users
+  ADD COLUMN onboarding_state JSONB DEFAULT '{}';
+```
+
+**API 变更**：
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| GET | `/api/v1/users/me/onboarding` | 获取当前用户引导状态 |
+| PATCH | `/api/v1/users/me/onboarding` | 更新引导步骤状态 |
+
+**验收标准**：
+- [ ] 新注册用户首次进入 `/app` 时显示 Welcome Screen
+- [ ] Welcome Screen 在有文档或 PRD 时不再显示
+- [ ] Setup Wizard 3 步引导可正常完成
+- [ ] 每个空状态页有对应的引导内容和操作按钮
+- [ ] "跳过引导"后不再显示（持久化到后端）
+- [ ] `users.onboarding_state` 字段正确更新
+
+---
+
+### #72 错误页面（404 / 500 / 403）
+
+**背景**：当前访问不存在的路由或发生服务器错误时，用户看到的是 Nuxt 默认的错误页面（白屏+调试信息），完全不符合产品风格。
+
+**目标**：实现与产品风格一致的自定义错误页面，包含友好的错误说明和可操作的返回入口。
+
+**错误页面设计**：
+
+| 错误码 | 触发场景 | 页面内容 |
+|--------|----------|---------|
+| 404 Not Found | 访问不存在的路由/资源 | 插画 + "页面不存在" + "返回首页"按钮 |
+| 403 Forbidden | 无权访问的工作区/资源 | 插画 + "没有访问权限" + "返回工作区"按钮 |
+| 500 Server Error | 服务器内部错误 | 插画 + "服务出现问题" + "刷新重试"按钮 + 错误 ID |
+
+**实现方式**：
+
+Nuxt 3 全局错误处理通过 `error.vue`（根目录）和 `~/pages/error/` 实现：
+
+```
+error.vue             # 全局错误捕获页（Nuxt 原生）
+pages/403.vue         # 403 页面
+```
+
+**错误 ID（Trace ID）**：
+
+500 错误页面展示 `reqId`（来自日志中间件注入），便于用户联系支持时提供排查线索：
+
+```
+错误 ID：abc123xyz456
+如问题持续存在，请截图此页面联系支持
+```
+
+**前端组件**：
+
+```
+components/error/
+  ├── ErrorIllustration.vue   # SVG 插画（区分错误类型）
+  └── ErrorActions.vue        # 操作按钮组（返回、刷新、联系支持）
+```
+
+**验收标准**：
+- [ ] 访问 `/xyz-nonexistent` 显示 404 页面（非 Nuxt 默认）
+- [ ] API 返回 403 后，前端跳转到 403 页面
+- [ ] 服务器 500 错误显示错误 ID（reqId）
+- [ ] 错误页面有"返回首页"/"返回上页"等操作按钮
+- [ ] 错误页面样式与整体设计系统一致（shadcn/ui + Tailwind）
+
+---
+
+### #73 Loading 状态与骨架屏统一
+
+**背景**：当前各页面的加载状态实现不一致：有的用 `Spinner`、有的用文字"加载中..."、有的没有任何 Loading 状态。骨架屏仅在部分组件中存在。用户在网络较慢时会遇到白屏。
+
+**目标**：为所有列表页和详情页建立统一的 Loading 状态规范，实现骨架屏组件库，并在现有核心页面中完成替换。
+
+**Loading 规范**：
+
+| 场景 | 实现方式 | 持续时间 |
+|------|---------|---------|
+| 页面初始加载（列表）| 骨架屏（SkeletonList）| 数据返回前 |
+| 页面初始加载（详情）| 骨架屏（SkeletonDetail）| 数据返回前 |
+| 按钮操作（提交/删除）| Button loading 状态（已有）| 操作完成前 |
+| 全局数据刷新 | 顶部进度条（NProgress 风格）| < 300ms 不显示 |
+| AI 生成（流式）| 打字机动效（已有）| 流式完成前 |
+
+**骨架屏组件清单**：
+
+```
+components/ui/skeleton/
+  ├── SkeletonCard.vue        # 卡片骨架（文档/PRD 列表项）
+  ├── SkeletonList.vue        # 列表骨架（多行）
+  ├── SkeletonDetail.vue      # 详情页骨架（标题 + 内容块）
+  ├── SkeletonTable.vue       # 表格骨架
+  └── SkeletonSidebar.vue     # 侧边栏骨架（工作区切换器）
+```
+
+**需要改造的核心页面**：
+
+| 页面 | 改造内容 |
+|------|---------|
+| `pages/knowledge-base.vue` | 文档列表 → SkeletonList |
+| `pages/generate.vue` | PRD 列表 → SkeletonList |
+| `pages/prototypes.vue` | 原型列表 → SkeletonList |
+| `pages/documents/[id].vue` | 文档详情 → SkeletonDetail |
+| `pages/projects/[id].vue` | PRD 详情 → SkeletonDetail |
+| `components/AppSidebar.vue` | 工作区切换器 → SkeletonSidebar |
+
+**顶部进度条**：
+
+使用 `nprogress` 库（或自实现）集成到 Nuxt 路由中间件，路由切换时自动显示/隐藏。
+
+**验收标准**：
+- [ ] 5 个 Skeleton 组件创建完毕，符合 shadcn/ui 风格
+- [ ] 上述 6 个核心页面完成骨架屏替换
+- [ ] 路由切换时顶部进度条正常工作
+- [ ] 网络节流（Chrome DevTools Slow 3G）下骨架屏正确显示
+
+---
+
+### #74 E2E 测试补全（核心流程）
+
+**背景**：`feature/49-e2e-tests` 分支实现了基础 E2E 测试框架（Playwright），但从未合并到 `develop`。核心业务流程（文档上传→RAG→PRD 生成→导出）缺乏端到端保障，无法在 CI 中验证完整链路。
+
+**目标**：将 E2E 测试框架合并入主线，补全核心业务流程的测试覆盖，确保 CI 通过。
+
+**测试场景清单**：
+
+| 测试场景 | 文件 | 优先级 |
+|---------|------|--------|
+| 用户注册 + 登录 + 登出 | `auth.spec.ts` | P0 |
+| 文档上传 → 处理完成（轮询状态） | `documents.spec.ts` | P0 |
+| PRD 生成（选模板 → 流式输出 → 保存）| `prd.spec.ts` | P0 |
+| 工作区创建 + 成员邀请 | `workspace.spec.ts` | P1 |
+| 原型生成 + 预览 | `prototype.spec.ts` | P1 |
+| Onboarding 流程（新用户）| `onboarding.spec.ts` | P1 |
+| 全局搜索（⌘K）| `search.spec.ts` | P2 |
+
+**CI 集成**：
+
+在 `.github/workflows/ci.yml` 中新增 `e2e` Job，依赖 `unit-test` Job 通过后执行：
+
+```yaml
+e2e:
+  needs: [unit-test]
+  runs-on: ubuntu-latest
+  services:
+    postgres:
+      image: pgvector/pgvector:pg14
+  steps:
+    - name: Install Playwright Browsers
+      run: pnpm exec playwright install --with-deps chromium
+    - name: Run E2E Tests
+      run: pnpm test:e2e --project=chromium
+```
+
+**测试环境配置**：
+
+```typescript
+// playwright.config.ts
+export default defineConfig({
+  testDir: './tests/e2e',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+  webServer: {
+    command: 'pnpm dev',
+    port: 3000,
+    reuseExistingServer: !process.env.CI,
+  },
+})
+```
+
+**验收标准**：
+- [ ] P0 测试场景（认证、文档上传、PRD 生成）全部通过
+- [ ] CI 中 E2E Job 在 Chromium 下正常运行
+- [ ] E2E 测试与现有单元测试相互隔离（不共享 vitest.config.ts）
+- [ ] 测试失败时保留截图和 Trace 文件作为 CI Artifact
+
+---
+
+### #75 健康检查深度完善
+
+**背景**：当前 `GET /api/v1/health` 只检查应用是否启动，未深度检查数据库连接、pgvector 扩展、对象存储连通性。在生产环境 Kubernetes 探针或负载均衡器健康检查中，浅层检查会掩盖真实故障。
+
+**目标**：将健康检查接口升级为深度检查，区分 `liveness`（存活）和 `readiness`（就绪）两种探针，适配 Kubernetes 部署。
+
+**健康检查端点**：
+
+| 端点 | 用途 | 检查内容 |
+|------|------|---------|
+| `GET /api/v1/health/live` | Kubernetes liveness 探针 | 进程是否存活（仅返回 200） |
+| `GET /api/v1/health/ready` | Kubernetes readiness 探针 | DB + pgvector + 存储全部就绪 |
+| `GET /api/v1/health` | 综合状态（向后兼容） | 同 `/ready`，保留字段结构 |
+
+**`/ready` 响应格式**：
+
+```typescript
+interface HealthCheckResponse {
+  status: 'healthy' | 'degraded' | 'unhealthy'
+  version: string        // package.json version
+  timestamp: string      // ISO 8601
+  checks: {
+    database: CheckResult
+    pgvector: CheckResult
+    storage: CheckResult
+    redis?: CheckResult   // 仅配置了 REDIS_URL 时包含
+  }
+  responseTimeMs: number
+}
+
+interface CheckResult {
+  status: 'ok' | 'error'
+  latencyMs: number
+  error?: string         // 仅 status=error 时包含
+}
+```
+
+**检查内容**：
+
+| 检查项 | 检测方式 | 超时 |
+|--------|---------|------|
+| `database` | `SELECT 1` | 3s |
+| `pgvector` | `SELECT * FROM pg_extension WHERE extname = 'vector'` | 3s |
+| `storage` | 写入并读取一个 1KB 测试文件 | 5s |
+| `redis` | `PING` 命令 | 2s |
+
+**响应状态码规则**：
+
+- 所有检查 `ok` → HTTP 200，status = `healthy`
+- 非核心检查失败（仅 redis）→ HTTP 200，status = `degraded`
+- 核心检查失败（database 或 pgvector）→ HTTP 503，status = `unhealthy`
+
+**验收标准**：
+- [ ] `/api/v1/health/live` 始终快速返回 200
+- [ ] `/api/v1/health/ready` 在数据库断开时返回 503
+- [ ] pgvector 扩展检查：模拟未安装时返回 `error`
+- [ ] 响应时间总计 < 8s（所有检查并行执行）
+- [ ] 现有 `/api/v1/health` 端点向后兼容（不破坏现有监控配置）
+
+---
+
+### #76 数据库迁移回滚支持
+
+**背景**：v0.1.0 至 v0.5.0 的所有数据库迁移脚本只有 `up`（正向迁移），没有 `down`（回滚）方向。在生产环境遇到严重 Bug 需要回滚版本时，数据库无法随应用代码一起回退，存在数据层不一致风险。
+
+**目标**：为从 v0.3.0 起的所有关键迁移脚本补充 `down` 方向，建立规范化的迁移文件命名和回滚执行工具。
+
+**迁移文件规范**：
+
+```
+migrations/
+  ├── {version}_{description}.up.sql    # 正向迁移（现有）
+  └── {version}_{description}.down.sql  # 回滚迁移（新增）
+```
+
+**需补充 down 脚本的迁移**（v0.3.0+）：
+
+| 迁移文件 | 回滚操作 |
+|---------|---------|
+| `add-workspace-members-invitations.sql` | DROP TABLE workspace_invitations |
+| `add-prd-feedbacks.sql` | DROP TABLE prd_feedbacks |
+| `add-prd-snapshots.sql` | DROP TABLE prd_snapshots |
+| `add-rag-retrieval-logs.sql` | DROP TABLE rag_retrieval_logs |
+| `add-rbac-roles.sql` | ALTER TYPE 回滚（移除 editor/viewer/guest）|
+| `add-logic-maps.sql` | DROP TABLE logic_maps |
+| `add-prd-templates.sql` | DROP TABLE prd_templates |
+| `add-ai-tasks.sql` | DROP TABLE ai_tasks |
+
+**回滚工具脚本**：
+
+```bash
+# scripts/migrate-down.ts 用法
+pnpm db:migrate-down --to v0.4.0   # 回滚到指定版本
+pnpm db:migrate-down --steps 2     # 回滚 2 个步骤
+pnpm db:migrate-status             # 查看当前迁移状态
+```
+
+**迁移版本表**：
+
+```sql
+CREATE TABLE IF NOT EXISTS migration_history (
+  id          SERIAL PRIMARY KEY,
+  version     TEXT NOT NULL,
+  filename    TEXT NOT NULL,
+  direction   TEXT NOT NULL CHECK (direction IN ('up', 'down')),
+  executed_at TIMESTAMPTZ DEFAULT NOW()
+);
+```
+
+**验收标准**：
+- [ ] v0.3.0 起所有新增表均有对应的 `.down.sql` 脚本
+- [ ] `pnpm db:migrate-down --steps 1` 能正确回滚最近一次迁移
+- [ ] `migration_history` 表记录所有执行过的迁移（包括回滚）
+- [ ] down 脚本在回滚时不影响其他模块的数据
+
+---
+
+### #77 移动端响应式基础适配
+
+**背景**：ArchMind 当前完全基于桌面端设计，在手机/平板设备上布局混乱（侧边栏遮盖内容、字体过小、按钮难点击）。虽然 MVP 主要面向桌面用户，但部分用户会在移动设备上查看 PRD 或文档。
+
+**目标**：完成最低可用的移动端基础适配（不追求完整移动端体验，确保主要功能在手机上"可用"）。
+
+**适配范围**（Mobile First，断点 `sm: 640px`）：
+
+| 区域 | 桌面 | 移动端 |
+|------|------|--------|
+| 侧边栏 | 固定显示 | 折叠，通过汉堡菜单展开（Sheet 组件）|
+| 顶部导航 | 完整工具栏 | 精简：Logo + 汉堡菜单 |
+| 文档/PRD 列表 | 3 列卡片 | 单列卡片 |
+| PRD 详情 | 左侧大纲 + 右侧内容 | 大纲折叠，仅显示内容 |
+| 对话侧边栏 | 固定左侧 | 底部抽屉或隐藏 |
+| 原型预览 | 全宽 iframe | 缩放适配（transform: scale）|
+
+**不在范围内**（明确排除）：
+- 移动端专属布局/交互设计
+- 触摸手势操作（拖拽排序等）
+- 原生 App 形态（PWA 壳、离线支持）
+
+**关键组件改造**：
+
+```
+components/AppSidebar.vue    # 新增移动端折叠逻辑，使用 Sheet 组件
+layouts/default.vue          # 响应式布局切换
+components/prd/             # PRD 详情大纲在移动端折叠
+```
+
+**验收标准**：
+- [ ] iPhone 14（390px）下侧边栏折叠，汉堡菜单可正常展开/收起
+- [ ] 文档列表、PRD 列表在移动端单列显示
+- [ ] 核心操作（上传、生成 PRD、查看文档）在移动端可正常完成
+- [ ] 无横向滚动条（max-width 不超出视口）
+
+---
+
+## 四、数据库变更汇总
+
+| Issue | 变更类型 | 说明 |
+|-------|----------|------|
+| #71 | 修改表 | `users` 新增 `onboarding_state` JSONB 字段 |
+| #76 | 新增表 | `migration_history`（迁移历史记录）|
+| #76 | 新增脚本 | 各迁移文件的 `.down.sql` 回滚版本 |
+
+所有迁移文件放在 `migrations/` 目录，命名格式：`v0.6.0_{功能描述}.up.sql` / `v0.6.0_{功能描述}.down.sql`。
+
+---
+
+## 五、API 变更汇总
+
+| Issue | 方法 | 路径 | 说明 |
+|-------|------|------|------|
+| #71 | GET | `/api/v1/users/me/onboarding` | 获取 Onboarding 状态 |
+| #71 | PATCH | `/api/v1/users/me/onboarding` | 更新 Onboarding 步骤 |
+| #75 | GET | `/api/v1/health/live` | Liveness 探针 |
+| #75 | GET | `/api/v1/health/ready` | Readiness 探针（深度检查）|
+
+---
+
+## 六、开发顺序建议
+
+考虑到依赖关系和风险，建议按以下顺序开发：
+
+```
+第一阶段（体验基础，用户可感知）
+  #72 错误页面（独立，无依赖，快速交付）
+  #73 骨架屏统一（可与 #72 并行）
+  #71 Onboarding 引导（依赖 #73 完成后骨架屏不影响引导UI）
+
+第二阶段（稳定性基础，CI/运维向）
+  #75 健康检查完善（独立，无 UI 依赖）
+  #76 数据库迁移回滚（基础设施，与其他功能并行）
+  #74 E2E 测试补全（依赖前两阶段功能稳定后再写测试）
+
+第三阶段（跨端体验）
+  #77 移动端适配（依赖 #72 #73 完成，确保错误页和骨架屏也适配）
+```
+
+---
+
+## 七、验收总结
+
+v0.6.0 整体验收标准：
+
+- [ ] 所有 P0 功能（#71 #72 #73）实现完毕
+- [ ] 所有 P1 功能（#74 #75 #76）实现完毕
+- [ ] P2 功能（#77）视进度决定是否纳入
+- [ ] 所有新增 API 端点有对应的 Zod 校验
+- [ ] 新增/修改数据库表有迁移脚本且经过本地验证
+- [ ] 所有 UI 组件使用 shadcn/ui，无浏览器原生弹窗
+- [ ] 单元测试覆盖率维持在 85% 以上
+- [ ] E2E P0 场景在 CI 中全部通过
+- [ ] `pnpm lint` + `pnpm typecheck` + `pnpm test` 全部通过
+
+---
+
+## 八、向后兼容性说明
+
+### 健康检查（#75）
+
+`GET /api/v1/health` 端点保留，响应结构与 v0.5.0 保持一致，只是内容更丰富。现有监控配置无需修改。
+
+### Onboarding 状态（#71）
+
+`onboarding_state` 为新增可选字段，默认值 `{}`。历史用户不会触发 Onboarding 流程（判断逻辑：`onboarding_state.skipped = true` 或 `completedAt` 不为空，或用户注册时间早于 v0.6.0 发布日期）。
+
+---
+
+*文档版本：v1.0 | 创建日期：2026-03-08 | 状态：已定稿 | 负责人：ArchMind Team*


### PR DESCRIPTION
## 变更内容

### docs/WIKI.md
- 功能矩阵补全：新增 RBAC、批量导出、Onboarding、E2E 测试、移动端适配、迁移回滚等 v0.4.0~v0.6.0 功能
- 产品指标更新：组件数 181→209+，新增 E2E 测试状态，版本号更新
- 测试策略章节重写：区分单元测试（~89%）和 E2E 测试（Playwright），列出各测试文件的 CI 状态
- 路线图补全：补充 v0.4.0、v0.5.0、v0.6.0 已发布内容，重新规划 v0.7.0~v1.0.0
- 已知问题更新：新增 workspaces.name 唯一约束风险、E2E flaky 问题
- 版本号和日期更新：0.3.0 → 0.6.0，2026-02-28 → 2026-03-09

### docs/DEPLOYMENT_CHECKLIST.md
- CI 检查项新增 E2E Tests
- 部署后验证章节：用 `vercel curl` 替代直接 curl，新增脏数据检查 SQL（workspace_id IS NULL）
- 日期更新

### docs/dev/
- 新增 v0.6.0-design.md 和 v0.6.0-requirements.md（设计文档）